### PR TITLE
Ubuntu install documentation improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,17 +72,14 @@ Supported versions:
 1. Import the Microsoft repository key:
 
     ```Bash
-    curl -sSL https://packages.microsoft.com/keys/microsoft.asc > /etc/apt/trusted.gpg.d/microsoft.asc
-    ```
-    If you get permission denied when executing command above you can run it with sudo as shown below:
-    ```Bash
     sudo sh -c 'curl -sSL https://packages.microsoft.com/keys/microsoft.asc > /etc/apt/trusted.gpg.d/microsoft.asc'
     ```
 
-2. Add `packages-microsoft-com-prod` repository:
+2. Add appropriate version of `packages-microsoft-com-prod` repository (either 20.04 or 22.04, script below retrieves Ubuntu version from lsb-release file:
 
-    ```
-    ver=20.04 # or 22.04
+    ```Bash
+    # ver value 20.04 or 22.04 gets retrieved from lsb-release file
+    ver=$(grep "DISTRIB_RELEASE=" /etc/lsb-release | grep -E [0-9]{2}.[0-9]{2} -o)
     apt-add-repository https://packages.microsoft.com/ubuntu/${ver}/prod
     ```
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Supported versions:
     sudo sh -c 'curl -sSL https://packages.microsoft.com/keys/microsoft.asc > /etc/apt/trusted.gpg.d/microsoft.asc'
     ```
 
-2. Add appropriate version of `packages-microsoft-com-prod` repository (either 20.04 or 22.04, script below retrieves Ubuntu version from lsb-release file:
+2. Add appropriate version of `packages-microsoft-com-prod` repository (either 20.04 or 22.04, script below retrieves Ubuntu version from lsb-release file and sets variable accordingly):
 
     ```Bash
     # ver value 20.04 or 22.04 gets retrieved from lsb-release file

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Supported versions:
     ```Bash
     # ver value 20.04 or 22.04 gets retrieved from lsb-release file
     ver=$(grep "DISTRIB_RELEASE=" /etc/lsb-release | grep -E [0-9]{2}.[0-9]{2} -o)
-    apt-add-repository https://packages.microsoft.com/ubuntu/${ver}/prod
+    sudo apt-add-repository https://packages.microsoft.com/ubuntu/${ver}/prod
     ```
 
 3. Install:

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Supported versions:
 3. Install:
 
     ```
-    apt-get install aztfy
+    sudo apt-get install aztfy
     ```
 
 #### AUR (Linux)

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ Supported versions:
     ```
     curl -sSL https://packages.microsoft.com/keys/microsoft.asc > /etc/apt/trusted.gpg.d/microsoft.asc
     ```
+    If you get permission denied when executing command above you can run it with sudo as shown below:
+    ```Bash
+    sudo sh -c 'curl -sSL https://packages.microsoft.com/keys/microsoft.asc > /etc/apt/trusted.gpg.d/microsoft.asc'
+    ```
 
 2. Add `packages-microsoft-com-prod` repository:
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Supported versions:
 
 1. Import the Microsoft repository key:
 
-    ```
+    ```Bash
     curl -sSL https://packages.microsoft.com/keys/microsoft.asc > /etc/apt/trusted.gpg.d/microsoft.asc
     ```
     If you get permission denied when executing command above you can run it with sudo as shown below:


### PR DESCRIPTION
Minor improvements to Ubuntu installation documentation section:
- Changed Import the Microsoft repository key command to be run with sudo (this is required, and simply adding sudo in front doesn't work due to redirect)
- Added line to retrieve Ubuntu version from from lsb-release file instead of manual adjustment of variable value