### PR TITLE
Add trace for effective CLI being issued (with non-interesting/sensitive flags removed)

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/urfave/cli/v2"
 )
 
@@ -44,4 +47,77 @@ type FlagSet struct {
 	flagRecursive bool
 	flagResName   string
 	flagResType   string
+}
+
+const (
+	ModeResource      = "resource"
+	ModeResourceGroup = "resource-group"
+	ModeQuery         = "query"
+	ModeMappingFile   = "mapping-file"
+)
+
+// DescribeCLI construct a description of the CLI based on the flag set and the specified mode.
+// The main reason is to record the usage of some "interesting" options in the telemetry.
+// Note that only insensitive values are recorded (i.e. subscription id, resource id, etc are not recorded)
+func (flag FlagSet) DescribeCLI(mode string) string {
+	args := []string{mode}
+
+	// The following flags are skipped eiter not interesting, or might contain sensitive info:
+	// - flagSubscriptionId
+	// - flagOutputDir
+	// - flagDevProvider
+	// - flagBackendConfig
+	// - all hflags
+
+	if flag.flagOverwrite {
+		args = append(args, "--overwrite=true")
+	}
+	if flag.flagAppend {
+		args = append(args, "--append=true")
+	}
+	if flag.flagBackendType != "" {
+		args = append(args, "--backend-type="+flag.flagBackendType)
+	}
+	if flag.flagFullConfig {
+		args = append(args, "--full-properties=true")
+	}
+	if flag.flagParallelism != 0 {
+		args = append(args, fmt.Sprintf("--parallelism=%d", flag.flagParallelism))
+	}
+	if flag.flagNonInteractive {
+		args = append(args, "--non-interactive=true")
+	}
+	if flag.flagContinue {
+		args = append(args, "--continue=true")
+	}
+	if flag.flagGenerateMappingFile {
+		args = append(args, "--generate-mapping-file=true")
+	}
+	if flag.flagHCLOnly {
+		args = append(args, "--hcl-only=true")
+	}
+	if flag.flagModulePath != "" {
+		args = append(args, "--module-path="+flag.flagModulePath)
+	}
+	switch mode {
+	case ModeResource:
+		if flag.flagResName != "" {
+			args = append(args, "--name="+flag.flagResName)
+		}
+		if flag.flagResType != "" {
+			args = append(args, "--type="+flag.flagResType)
+		}
+	case ModeResourceGroup:
+		if flag.flagPattern != "" {
+			args = append(args, "--name-pattern="+flag.flagPattern)
+		}
+	case ModeQuery:
+		if flag.flagPattern != "" {
+			args = append(args, "--name-pattern="+flag.flagPattern)
+		}
+		if flag.flagRecursive {
+			args = append(args, "--recursive=true")
+		}
+	}
+	return "aztfexport " + strings.Join(args, " ")
 }

--- a/main.go
+++ b/main.go
@@ -354,7 +354,7 @@ func main() {
 				},
 			},
 			{
-				Name:      "resource",
+				Name:      ModeResource,
 				Aliases:   []string{"res"},
 				Usage:     "Exporting a single resource",
 				UsageText: "aztfexport resource [option] <resource id>",
@@ -405,11 +405,11 @@ func main() {
 						cfg.CommonConfig.OutputFileNames = safeOutputFileNames
 					}
 
-					return realMain(c.Context, cfg, flagset.flagNonInteractive, flagset.hflagMockClient, flagset.hflagPlainUI, flagset.flagGenerateMappingFile, flagset.hflagProfile)
+					return realMain(c.Context, cfg, flagset.flagNonInteractive, flagset.hflagMockClient, flagset.hflagPlainUI, flagset.flagGenerateMappingFile, flagset.hflagProfile, flagset.DescribeCLI(ModeResource))
 				},
 			},
 			{
-				Name:      "resource-group",
+				Name:      ModeResourceGroup,
 				Aliases:   []string{"rg"},
 				Usage:     "Exporting a resource group and the nested resources resides within it",
 				UsageText: "aztfexport resource-group [option] <resource group name>",
@@ -456,11 +456,11 @@ func main() {
 						cfg.CommonConfig.OutputFileNames = safeOutputFileNames
 					}
 
-					return realMain(c.Context, cfg, flagset.flagNonInteractive, flagset.hflagMockClient, flagset.hflagPlainUI, flagset.flagGenerateMappingFile, flagset.hflagProfile)
+					return realMain(c.Context, cfg, flagset.flagNonInteractive, flagset.hflagMockClient, flagset.hflagPlainUI, flagset.flagGenerateMappingFile, flagset.hflagProfile, flagset.DescribeCLI(ModeResourceGroup))
 				},
 			},
 			{
-				Name:      "query",
+				Name:      ModeQuery,
 				Usage:     "Exporting a customized scope of resources determined by an Azure Resource Graph where predicate",
 				UsageText: "aztfexport query [option] <ARG where predicate>",
 				Flags:     queryFlags,
@@ -506,11 +506,11 @@ func main() {
 						cfg.CommonConfig.OutputFileNames = safeOutputFileNames
 					}
 
-					return realMain(c.Context, cfg, flagset.flagNonInteractive, flagset.hflagMockClient, flagset.hflagPlainUI, flagset.flagGenerateMappingFile, flagset.hflagProfile)
+					return realMain(c.Context, cfg, flagset.flagNonInteractive, flagset.hflagMockClient, flagset.hflagPlainUI, flagset.flagGenerateMappingFile, flagset.hflagProfile, flagset.DescribeCLI(ModeQuery))
 				},
 			},
 			{
-				Name:      "mapping-file",
+				Name:      ModeMappingFile,
 				Aliases:   []string{"map"},
 				Usage:     "Exporting a customized scope of resources determined by the resource mapping file",
 				UsageText: "aztfexport mapping-file [option] <resource mapping file>",
@@ -555,7 +555,7 @@ func main() {
 						cfg.CommonConfig.OutputFileNames = safeOutputFileNames
 					}
 
-					return realMain(c.Context, cfg, flagset.flagNonInteractive, flagset.hflagMockClient, flagset.hflagPlainUI, flagset.flagGenerateMappingFile, flagset.hflagProfile)
+					return realMain(c.Context, cfg, flagset.flagNonInteractive, flagset.hflagMockClient, flagset.hflagPlainUI, flagset.flagGenerateMappingFile, flagset.hflagProfile, flagset.DescribeCLI(ModeMappingFile))
 				},
 			},
 		},
@@ -729,7 +729,7 @@ func subscriptionIdFromCLI() (string, error) {
 	return strconv.Unquote(strings.TrimSpace(stdout.String()))
 }
 
-func realMain(ctx context.Context, cfg config.Config, batch, mockMeta, plainUI, genMapFile bool, profileType string) (result error) {
+func realMain(ctx context.Context, cfg config.Config, batch, mockMeta, plainUI, genMapFile bool, profileType string, effectiveCLI string) (result error) {
 	switch strings.ToLower(profileType) {
 	case "cpu":
 		defer profile.Start(profile.CPUProfile, profile.ProfilePath("."), profile.NoShutdownHook).Stop()
@@ -758,6 +758,7 @@ func realMain(ctx context.Context, cfg config.Config, batch, mockMeta, plainUI, 
 
 	log.Printf("[INFO] aztfexport starts with config: %#v", cfg)
 	tc.Trace(telemetry.Info, "aztfexport starts")
+	tc.Trace(telemetry.Info, "Effective CLI: "+effectiveCLI)
 
 	// Run in non-interactive mode
 	if batch {


### PR DESCRIPTION
This PR adds one more tracing at the begining of the tool, to record the "effective" CLI being issued (which indicates that the flag resolving are taken into considerations, e.g. the default value is populated). Not all flags are being considered, where the non interesting flags and flags that may contain sensitive info are ignored.