### PR TITLE
Resource mapping file will now be generated together with the `import.tf` that is the TF plannable import blocks

### DIFF
--- a/internal/meta/base_meta.go
+++ b/internal/meta/base_meta.go
@@ -178,6 +178,9 @@ func NewBaseMeta(cfg config.CommonConfig) (*baseMeta, error) {
 	if outputFileNames.MainFileName == "" {
 		outputFileNames.MainFileName = "main.tf"
 	}
+	if outputFileNames.ImportBlockFileName == "" {
+		outputFileNames.ImportBlockFileName = "import.tf"
+	}
 
 	tc := cfg.TelemetryClient
 	if tc == nil {
@@ -361,24 +364,40 @@ func (meta baseMeta) GenerateCfg(ctx context.Context, l ImportList) error {
 
 func (meta baseMeta) ExportResourceMapping(_ context.Context, l ImportList) error {
 	m := resmap.ResourceMapping{}
+	f := hclwrite.NewFile()
+	body := f.Body()
 	for _, item := range l {
 		if item.Skip() {
 			continue
 		}
+
+		// The JSON mapping record
 		m[item.AzureResourceID.String()] = resmap.ResourceMapEntity{
 			ResourceId:   item.TFResourceId,
 			ResourceType: item.TFAddr.Type,
 			ResourceName: item.TFAddr.Name,
 		}
+
+		// The import block
+		blk := hclwrite.NewBlock("import", nil)
+		blk.Body().SetAttributeValue("id", cty.StringVal(item.TFResourceId))
+		blk.Body().SetAttributeTraversal("to", hcl.Traversal{hcl.TraverseRoot{Name: item.TFAddr.Type}, hcl.TraverseAttr{Name: item.TFAddr.Name}})
+		body.AppendBlock(blk)
 	}
-	output := filepath.Join(meta.outdir, ResourceMappingFileName)
 	b, err := json.MarshalIndent(m, "", "\t")
 	if err != nil {
 		return fmt.Errorf("JSON marshalling the resource mapping: %v", err)
 	}
+	oMapFile := filepath.Join(meta.outdir, ResourceMappingFileName)
 	// #nosec G306
-	if err := os.WriteFile(output, b, 0644); err != nil {
-		return fmt.Errorf("writing the resource mapping to %s: %v", output, err)
+	if err := os.WriteFile(oMapFile, b, 0644); err != nil {
+		return fmt.Errorf("writing the resource mapping to %s: %v", oMapFile, err)
+	}
+
+	oImportFile := filepath.Join(meta.moduleDir, meta.outputFileNames.ImportBlockFileName)
+	// #nosec G306
+	if err := os.WriteFile(oImportFile, f.Bytes(), 0644); err != nil {
+		return fmt.Errorf("writing the import block to %s: %v", oImportFile, err)
 	}
 	return nil
 }

--- a/internal/meta/base_meta.go
+++ b/internal/meta/base_meta.go
@@ -396,7 +396,7 @@ func (meta baseMeta) ExportResourceMapping(ctx context.Context, l ImportList) er
 		if err != nil {
 			return fmt.Errorf("getting terraform version")
 		}
-		supportPlannableImport = ver.GreaterThanOrEqual(version.Must(version.NewVersion("v1.6.0")))
+		supportPlannableImport = ver.GreaterThanOrEqual(version.Must(version.NewVersion("v1.5.0")))
 	}
 	if supportPlannableImport {
 		f := hclwrite.NewFile()

--- a/main.go
+++ b/main.go
@@ -324,9 +324,10 @@ func main() {
 	mappingFileFlags := append([]cli.Flag{}, commonFlags...)
 
 	safeOutputFileNames := config.OutputFileNames{
-		TerraformFileName: "terraform.aztfexport.tf",
-		ProviderFileName:  "provider.aztfexport.tf",
-		MainFileName:      "main.aztfexport.tf",
+		TerraformFileName:   "terraform.aztfexport.tf",
+		ProviderFileName:    "provider.aztfexport.tf",
+		MainFileName:        "main.aztfexport.tf",
+		ImportBlockFileName: "import.aztfexport.tf",
 	}
 
 	app := &cli.App{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,6 +15,8 @@ type OutputFileNames struct {
 	ProviderFileName string
 	// The filename for the generated "main.tf" (default)
 	MainFileName string
+	// The filename for the generated "import.tf" (default)
+	ImportBlockFileName string
 }
 
 type CommonConfig struct {


### PR DESCRIPTION
The `-g` and <kbd>s</kbd> generates both a JSON versioned resource mapping file and the `import.tf` that is the new TF plannable import blocks, e.g.

```
>  cat import.tf
import {
  id = "/subscriptions/xxxx/resourceGroups/AZTFY-VMDISK/providers/Microsoft.Compute/virtualMachines/aztfy-test/extensions/Microsoft.Azure.Monitor.AzureMonitorLinuxAgent"
  to = azurerm_virtual_machine_extension.res-0
}
import {
  id = "/subscriptions/xxxx/resourceGroups/AZTFY-VMDISK/providers/Microsoft.Compute/virtualMachines/aztfy-test/extensions/Microsoft.Azure.Security.Monitoring.AzureSecurityLinuxAgent"
  to = azurerm_virtual_machine_extension.res-1
}

#...
```

Users are welcome to grab the `import.tf` and proceed the plannable import process for another importing experience that is provided by TF official.

This behavior only takes effect when the `terraform` under used is >= v1.5.0.

~The generated `import.tf` is not really working, see: https://github.com/hashicorp/terraform/issues/33201~

@stemaMSFT The document in MS Doc needs to be updated once this PR is merged...


