### PR TITLE
Update aztft to move azurerm_virtual_machine out of skip list

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/magodo/armid v0.0.0-20220923023118-aec41eaf7370
 	github.com/magodo/azlist v0.0.0-20230518102903-58631213ca2c
-	github.com/magodo/aztft v0.3.1-0.20230710014320-77ec0ac9bd7e
+	github.com/magodo/aztft v0.3.1-0.20230711053954-912460dad35a
 	github.com/magodo/spinner v0.0.0-20220720073946-50f31b2dc5a6
 	github.com/magodo/terraform-client-go v0.0.0-20230323074119-02ceb732dd25
 	github.com/magodo/textinput v0.0.0-20210913072708-7d24f2b4b0c0

--- a/go.sum
+++ b/go.sum
@@ -224,8 +224,8 @@ github.com/magodo/armid v0.0.0-20220923023118-aec41eaf7370 h1:n8RrB7jcZ9lQE7tyF2
 github.com/magodo/armid v0.0.0-20220923023118-aec41eaf7370/go.mod h1:rR8E7zfGMbmfnSQvrkFiWYdhrfTqsVSltelnZB09BwA=
 github.com/magodo/azlist v0.0.0-20230518102903-58631213ca2c h1:EcZcI48XRVOFF32JYn/si26mlSeNSVJJ51+GlUQhvNg=
 github.com/magodo/azlist v0.0.0-20230518102903-58631213ca2c/go.mod h1:pkK04XFrJfiki47pbsmEBUAW/fbF2OiFhK37gq4TzOk=
-github.com/magodo/aztft v0.3.1-0.20230710014320-77ec0ac9bd7e h1:gxIlQ4Xo5Euax0P2mrwaITu2D58QOPrR9Jwr9xNQdSg=
-github.com/magodo/aztft v0.3.1-0.20230710014320-77ec0ac9bd7e/go.mod h1:Iy8TZv9TJJdDK9lYBW14uPp3Eokn4Ro7a7bXrY3LBoo=
+github.com/magodo/aztft v0.3.1-0.20230711053954-912460dad35a h1:fBz6l2A4OeGpL2KrI0CFf/bwZcAFx0XTlm/ljqAgWlg=
+github.com/magodo/aztft v0.3.1-0.20230711053954-912460dad35a/go.mod h1:Iy8TZv9TJJdDK9lYBW14uPp3Eokn4Ro7a7bXrY3LBoo=
 github.com/magodo/spinner v0.0.0-20220720073946-50f31b2dc5a6 h1:CElHO4hPXC+Eivy8sUC/WrnH3jmQzdF2x0lEXBEYul8=
 github.com/magodo/spinner v0.0.0-20220720073946-50f31b2dc5a6/go.mod h1:Cn4fFwFH/Ddw9sjWPeSS72bNaxbM+FRXf7pkGEDReq8=
 github.com/magodo/terraform-client-go v0.0.0-20230323074119-02ceb732dd25 h1:V4R1wcjD/fYQh3Qx/xUyB8xTZgJ7P+WGtHqYpjs+mTU=


### PR DESCRIPTION
Follow up of #425, related to #412