### PR TITLE
Import block stops generate for skipped resources

### DIFF
--- a/internal/meta/base_meta.go
+++ b/internal/meta/base_meta.go
@@ -402,6 +402,10 @@ func (meta baseMeta) ExportResourceMapping(ctx context.Context, l ImportList) er
 		f := hclwrite.NewFile()
 		body := f.Body()
 		for _, item := range l {
+			if item.Skip() {
+				continue
+			}
+
 			// The import block
 			blk := hclwrite.NewBlock("import", nil)
 			blk.Body().SetAttributeValue("id", cty.StringVal(item.TFResourceId))


### PR DESCRIPTION
Import block stops generate for skipped resources (same as the resource mapping file).

Otherwise, will hit error as reported at https://github.com/Azure/aztfexport/pull/425#issuecomment-1629148795 