### PR TITLE
New auth method: Fedorated Workload Identity (a.k.a OIDC)

### DIFF
--- a/auth_oidc.go
+++ b/auth_oidc.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+)
+
+var _ azcore.TokenCredential = &OidcCredential{}
+
+type OidcCredential struct {
+	requestToken string
+	requestUrl   string
+
+	token         string
+	tokenFilePath string
+
+	cred *azidentity.ClientAssertionCredential
+}
+
+type OidcCredentialOptions struct {
+	azcore.ClientOptions
+	TenantID      string
+	ClientID      string
+	RequestToken  string
+	RequestUrl    string
+	Token         string
+	TokenFilePath string
+}
+
+func NewOidcCredential(options *OidcCredentialOptions) (*OidcCredential, error) {
+	w := &OidcCredential{
+		requestToken:  options.RequestToken,
+		requestUrl:    options.RequestUrl,
+		token:         options.Token,
+		tokenFilePath: options.TokenFilePath,
+	}
+
+	cred, err := azidentity.NewClientAssertionCredential(options.TenantID, options.ClientID, w.getAssertion, &azidentity.ClientAssertionCredentialOptions{ClientOptions: options.ClientOptions})
+	if err != nil {
+		return nil, err
+	}
+
+	w.cred = cred
+	return w, nil
+}
+
+func (w *OidcCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return w.cred.GetToken(ctx, opts)
+}
+
+func (w *OidcCredential) getAssertion(ctx context.Context) (string, error) {
+	if w.token != "" {
+		return w.token, nil
+	}
+
+	if w.tokenFilePath != "" {
+		idTokenData, err := os.ReadFile(w.tokenFilePath)
+		if err != nil {
+			return "", fmt.Errorf("reading token file: %v", err)
+		}
+
+		return string(idTokenData), nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, w.requestUrl, http.NoBody)
+	if err != nil {
+		return "", fmt.Errorf("getAssertion: failed to build request")
+	}
+
+	query, err := url.ParseQuery(req.URL.RawQuery)
+	if err != nil {
+		return "", fmt.Errorf("getAssertion: cannot parse URL query")
+	}
+
+	if query.Get("audience") == "" {
+		query.Set("audience", "api://AzureADTokenExchange")
+		req.URL.RawQuery = query.Encode()
+	}
+
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", w.requestToken))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("getAssertion: cannot request token: %v", err)
+	}
+
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", fmt.Errorf("getAssertion: cannot parse response: %v", err)
+	}
+
+	if c := resp.StatusCode; c < 200 || c > 299 {
+		return "", fmt.Errorf("getAssertion: received HTTP status %d with response: %s", resp.StatusCode, body)
+	}
+
+	var tokenRes struct {
+		Count *int    `json:"count"`
+		Value *string `json:"value"`
+	}
+	if err := json.Unmarshal(body, &tokenRes); err != nil {
+		return "", fmt.Errorf("getAssertion: cannot unmarshal response: %v", err)
+	}
+
+	if tokenRes.Value == nil {
+		return "", fmt.Errorf("getAssertion: nil JWT assertion received from OIDC provider")
+	}
+
+	return *tokenRes.Value, nil
+}

--- a/command_before_func.go
+++ b/command_before_func.go
@@ -60,13 +60,14 @@ func commandBeforeFunc(fset *FlagSet) func(ctx *cli.Context) error {
 			fset.flagUseEnvironmentCred,
 			fset.flagUseManagedIdentityCred,
 			fset.flagUseAzureCLICred,
+			fset.flagUseOIDCCred,
 		} {
 			if ok {
 				occur += 1
 			}
 		}
 		if occur > 1 {
-			return fmt.Errorf("only one of `--use-environment-cred`, `--use-managed-identity-cred` and `--use-azure-cli-cred` can be specified")
+			return fmt.Errorf("only one of `--use-environment-cred`, `--use-managed-identity-cred`, `--use-azure-cli-cred` and `--use-oidc-cred` can be specified")
 		}
 
 		// Initialize output directory

--- a/command_before_func_test.go
+++ b/command_before_func_test.go
@@ -224,7 +224,7 @@ func TestCommondBeforeFunc(t *testing.T) {
 				flagUseEnvironmentCred: true,
 				flagUseAzureCLICred:    true,
 			},
-			err: "only one of `--use-environment-cred`, `--use-managed-identity-cred` and `--use-azure-cli-cred` can be specified",
+			err: "only one of `--use-environment-cred`, `--use-managed-identity-cred`, `--use-azure-cli-cred` and `--use-oidc-cred` can be specified",
 		},
 	}
 

--- a/flag.go
+++ b/flag.go
@@ -11,26 +11,33 @@ var flagset FlagSet
 
 type FlagSet struct {
 	// common flags
-	flagEnv                    string
-	flagSubscriptionId         string
+	flagEnv                 string
+	flagSubscriptionId      string
+	flagOutputDir           string
+	flagOverwrite           bool
+	flagAppend              bool
+	flagDevProvider         bool
+	flagProviderVersion     string
+	flagBackendType         string
+	flagBackendConfig       cli.StringSlice
+	flagFullConfig          bool
+	flagParallelism         int
+	flagContinue            bool
+	flagNonInteractive      bool
+	flagPlainUI             bool
+	flagGenerateMappingFile bool
+	flagHCLOnly             bool
+	flagModulePath          string
+
+	// common flags (auth)
 	flagUseEnvironmentCred     bool
 	flagUseManagedIdentityCred bool
 	flagUseAzureCLICred        bool
-	flagOutputDir              string
-	flagOverwrite              bool
-	flagAppend                 bool
-	flagDevProvider            bool
-	flagProviderVersion        string
-	flagBackendType            string
-	flagBackendConfig          cli.StringSlice
-	flagFullConfig             bool
-	flagParallelism            int
-	flagContinue               bool
-	flagNonInteractive         bool
-	flagPlainUI                bool
-	flagGenerateMappingFile    bool
-	flagHCLOnly                bool
-	flagModulePath             string
+	flagUseOIDCCred            bool
+	flagOIDCRequestToken       string
+	flagOIDCRequestURL         string
+	flagOIDCTokenFilePath      string
+	flagOIDCToken              string
 
 	// common flags (hidden)
 	hflagMockClient         bool
@@ -81,15 +88,6 @@ func (flag FlagSet) DescribeCLI(mode string) string {
 	if flag.flagOverwrite {
 		args = append(args, "--overwrite=true")
 	}
-	if flag.flagUseEnvironmentCred {
-		args = append(args, "--use-environment-cred=true")
-	}
-	if flag.flagUseManagedIdentityCred {
-		args = append(args, "--use-managed-identity-cred=true")
-	}
-	if flag.flagUseAzureCLICred {
-		args = append(args, "--use-azure-cli-cred=true")
-	}
 	if flag.flagAppend {
 		args = append(args, "--append=true")
 	}
@@ -120,11 +118,37 @@ func (flag FlagSet) DescribeCLI(mode string) string {
 	if flag.flagHCLOnly {
 		args = append(args, "--hcl-only=true")
 	}
-	if flag.hflagTFClientPluginPath != "" {
-		args = append(args, "--tfclient-plugin-path="+flag.hflagTFClientPluginPath)
-	}
 	if flag.flagModulePath != "" {
 		args = append(args, "--module-path="+flag.flagModulePath)
+	}
+
+	if flag.flagUseEnvironmentCred {
+		args = append(args, "--use-environment-cred=true")
+	}
+	if flag.flagUseManagedIdentityCred {
+		args = append(args, "--use-managed-identity-cred=true")
+	}
+	if flag.flagUseAzureCLICred {
+		args = append(args, "--use-azure-cli-cred=true")
+	}
+	if flag.flagUseOIDCCred {
+		args = append(args, "--use-oidc-cred=true")
+	}
+	if flag.flagOIDCRequestToken != "" {
+		args = append(args, "--oidc-request-token=*")
+	}
+	if flag.flagOIDCRequestURL != "" {
+		args = append(args, "--oidc-request-url="+flag.flagOIDCRequestURL)
+	}
+	if flag.flagOIDCTokenFilePath != "" {
+		args = append(args, "--oidc-token-file-path="+flag.flagOIDCTokenFilePath)
+	}
+	if flag.flagOIDCToken != "" {
+		args = append(args, "--oidc-token=*")
+	}
+
+	if flag.hflagTFClientPluginPath != "" {
+		args = append(args, "--tfclient-plugin-path="+flag.hflagTFClientPluginPath)
 	}
 	switch mode {
 	case ModeResource:


### PR DESCRIPTION
This PR add supports for auth method Fedorated Workload Identity. In order to use this auth method for github, users need to follow up the https:registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/service_principal_oidc to setup the SP and also the necessary env var. Then launch the command with option: `--use-oidc-cred`.

A example workflow can be found at: https:github.com/magodo/aztfy-oidc-test/blob/2eaad2c1f47cf369955fb7a1f715a05488faa48f/.github/workflows/test.yaml. Basically, following settings are required:

```
permissions:
  id-token: write
  contents: read

jobs:
  test:
    runs-on: ubuntu-latest
      #...
      - name: Export the demo rg using oidc
        run:
          aztfexport rg -n -f -use-oidc-cred --plain-ui my-rg
        env:
          ARM_USE_OIDC: true
          ARM_TENANT_ID: ${{ secrets. ARM_TENANT_ID }}
          ARM_SUBSCRIPTION_ID: ${{ secrets. ARM_SUBSCRIPTION_ID }}
          ARM_CLIENT_ID: ${{ secrets. ARM_CLIENT_ID }}
```

Note that the `ARM_USE_OIDC` env var is necessary to be used for the AzureRM provider.

Fix https://github.com/Azure/aztfexport/issues/436.