### PR TITLE
Stick on gosec v2.16.0

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@master
+        uses: securego/gosec@v2.16.0
         with:
           args: './...'
 


### PR DESCRIPTION
The now latest version v2.17.0 will cause error as below:

    Golang errors in file: []:

      > [line 0 : column 0] - error obtaining VCS status: exit status 128
            Use -buildvcs=false to disable VCS stamping.

      > [line 0 : column 0] - error obtaining VCS status: exit status 128
            Use -buildvcs=false to disable VCS stamping.

      > [line 0 : column 0] - error obtaining VCS status: exit status 128
            Use -buildvcs=false to disable VCS stamping.

      > [line 0 : column 0] - error obtaining VCS status: exit status 128
            Use -buildvcs=false to disable VCS stamping.

This probably due to the fact that 2.17.0 updated its Go version, which might conflicts with the github action OS installed version.