### PR TITLE
feature: add support for exporting to `azapi` provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .vscode
 dist/
+.idea
+aztfexport

--- a/internal/meta/base_meta.go
+++ b/internal/meta/base_meta.go
@@ -581,15 +581,14 @@ func (meta *baseMeta) buildTerraformConfig(backendType string) string {
 func (meta *baseMeta) buildProviderConfig() string {
 	f := hclwrite.NewEmptyFile()
 
-	var body *hclwrite.Body
 	if meta.useAzAPI() {
-		body = f.Body().AppendNewBlock("provider", []string{"azapi"}).Body()
+		f.Body().AppendNewBlock("provider", []string{"azapi"}).Body()
 	} else {
-		body = f.Body().AppendNewBlock("provider", []string{"azurerm"}).Body()
-	}
-	body.AppendNewBlock("features", nil)
-	for k, v := range meta.providerConfig {
-		body.SetAttributeValue(k, v)
+		body := f.Body().AppendNewBlock("provider", []string{"azurerm"}).Body()
+		body.AppendNewBlock("features", nil)
+		for k, v := range meta.providerConfig {
+			body.SetAttributeValue(k, v)
+		}
 	}
 	return string(f.Bytes())
 }

--- a/internal/meta/base_meta.go
+++ b/internal/meta/base_meta.go
@@ -527,18 +527,14 @@ func (meta *baseMeta) buildTerraformConfigForImportDir() string {
 	}
 
 	if meta.useAzAPI() {
-		return fmt.Sprintf(`terraform {
+		return `terraform {
   required_providers {
-    azurerm = {
-      source = "hashicorp/azurerm"
-      version = "%s"
-    }
 	azapi = {
       source = "azure/azapi"
 	}
   }
 }
-`, meta.providerVersion)
+`
 	}
 
 	return fmt.Sprintf(`terraform {
@@ -564,16 +560,12 @@ func (meta *baseMeta) buildTerraformConfig(backendType string) string {
 		return fmt.Sprintf(`terraform {
   backend %q {}
   required_providers {
-    azurerm = {
-      source = "hashicorp/azurerm"
-      version = "%s"
-    }
 	azapi = {
       source = "azure/azapi"
 	}
   }
 }
-`, backendType, meta.providerVersion)
+`, backendType)
 	}
 
 	return fmt.Sprintf(`terraform {

--- a/internal/meta/base_meta.go
+++ b/internal/meta/base_meta.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Azure/aztfexport/internal/resourceset"
 	"github.com/hashicorp/go-version"
 	tfjson "github.com/hashicorp/terraform-json"
 
@@ -260,7 +259,6 @@ func (meta *baseMeta) CleanTFState(ctx context.Context, addr string) {
 func (meta *baseMeta) ParallelImport(ctx context.Context, items []*ImportItem) error {
 	meta.tc.Trace(telemetry.Info, "ParallelImport Enter")
 	defer meta.tc.Trace(telemetry.Info, "ParallelImport Leave")
-	// return nil
 
 	itemsCh := make(chan *ImportItem, len(items))
 	for _, item := range items {
@@ -589,7 +587,7 @@ func (meta *baseMeta) buildProviderConfig() string {
 	}
 
 	if meta.useAzAPI() {
-		_ = f.Body().AppendNewBlock("provider", []string{"azapi"}).Body()
+		f.Body().AppendNewBlock("provider", []string{"azapi"}).Body()
 	}
 	return string(f.Bytes())
 }
@@ -1064,13 +1062,6 @@ func (meta *baseMeta) deinit_tf(ctx context.Context) error {
 		os.RemoveAll(dir)
 	}
 	return nil
-}
-
-func (meta *baseMeta) GenTFResources(set *resourceset.AzureResourceSet) []resourceset.TFResource {
-	if meta.useAzAPI() {
-		return set.ToAzAPIResources()
-	}
-	return set.ToTFResources(meta.parallelism, meta.azureSDKCred, meta.azureSDKClientOpt)
 }
 
 func getModuleDir(modulePaths []string, moduleDir string) (string, error) {

--- a/internal/meta/base_meta.go
+++ b/internal/meta/base_meta.go
@@ -580,14 +580,16 @@ func (meta *baseMeta) buildTerraformConfig(backendType string) string {
 
 func (meta *baseMeta) buildProviderConfig() string {
 	f := hclwrite.NewEmptyFile()
-	body := f.Body().AppendNewBlock("provider", []string{"azurerm"}).Body()
+
+	var body *hclwrite.Body
+	if meta.useAzAPI() {
+		body = f.Body().AppendNewBlock("provider", []string{"azapi"}).Body()
+	} else {
+		body = f.Body().AppendNewBlock("provider", []string{"azurerm"}).Body()
+	}
 	body.AppendNewBlock("features", nil)
 	for k, v := range meta.providerConfig {
 		body.SetAttributeValue(k, v)
-	}
-
-	if meta.useAzAPI() {
-		f.Body().AppendNewBlock("provider", []string{"azapi"}).Body()
 	}
 	return string(f.Bytes())
 }

--- a/internal/meta/meta_query.go
+++ b/internal/meta/meta_query.go
@@ -60,7 +60,8 @@ func (meta *MetaQuery) ListResource(ctx context.Context) (ImportList, error) {
 	}
 
 	log.Printf("[DEBUG] Azure Resource set map to TF resource set")
-	rl := rset.ToTFResources(meta.parallelism, meta.azureSDKCred, meta.azureSDKClientOpt)
+	// rl := rset.ToTFResources(meta.parallelism, meta.azureSDKCred, meta.azureSDKClientOpt)
+	rl := meta.GenTFResources(rset)
 
 	var l ImportList
 	for i, res := range rl {

--- a/internal/meta/meta_res.go
+++ b/internal/meta/meta_res.go
@@ -44,7 +44,7 @@ func (meta MetaResource) ScopeName() string {
 }
 
 func (meta *MetaResource) ListResource(_ context.Context) (ImportList, error) {
-	resourceSet := resourceset.AzureResourceSet{
+	resourceSet := &resourceset.AzureResourceSet{
 		Resources: []resourceset.AzureResource{
 			{
 				Id: meta.AzureId,
@@ -52,7 +52,7 @@ func (meta *MetaResource) ListResource(_ context.Context) (ImportList, error) {
 		},
 	}
 	log.Printf("[DEBUG] Azure Resource set map to TF resource set")
-	rl := resourceSet.ToTFResources(meta.parallelism, meta.azureSDKCred, meta.azureSDKClientOpt)
+	rl := meta.GenTFResources(resourceSet)
 
 	// This is to record known resource types. In case there is a known resource type and there comes another same typed resource,
 	// then we need to modify the resource name. Otherwise, there will be a resource address conflict.
@@ -67,7 +67,7 @@ func (meta *MetaResource) ListResource(_ context.Context) (ImportList, error) {
 			name += fmt.Sprintf("-%d", rtCnt[res.TFType]-1)
 		}
 		tfAddr := tfaddr.TFAddr{
-			Type: res.TFType, //this might be empty if have multiple matches in aztft
+			Type: res.TFType, // this might be empty if have multiple matches in aztft
 			Name: name,
 		}
 		item := ImportItem{

--- a/internal/meta/meta_rg.go
+++ b/internal/meta/meta_rg.go
@@ -45,17 +45,24 @@ func (meta *MetaResourceGroup) ListResource(ctx context.Context) (ImportList, er
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("[DEBUG] Populate resource set")
-	if err := rset.PopulateResource(); err != nil {
-		return nil, fmt.Errorf("tweaking single resources in the azure resource set: %v", err)
-	}
-	log.Printf("[DEBUG] Reduce resource set")
-	if err := rset.ReduceResource(); err != nil {
-		return nil, fmt.Errorf("tweaking across resources in the azure resource set: %v", err)
-	}
 
-	log.Printf("[DEBUG] Azure Resource set map to TF resource set")
-	rl := meta.GenTFResources(rset)
+	var rl []resourceset.TFResource
+	if meta.useAzAPI() {
+		rl = rset.ToTFAzAPIResources()
+	} else {
+
+		log.Printf("[DEBUG] Populate resource set")
+		if err := rset.PopulateResource(); err != nil {
+			return nil, fmt.Errorf("tweaking single resources in the azure resource set: %v", err)
+		}
+		log.Printf("[DEBUG] Reduce resource set")
+		if err := rset.ReduceResource(); err != nil {
+			return nil, fmt.Errorf("tweaking across resources in the azure resource set: %v", err)
+		}
+
+		log.Printf("[DEBUG] Azure Resource set map to TF resource set")
+		rl = rset.ToTFAzureRMResources(meta.parallelism, meta.azureSDKCred, meta.azureSDKClientOpt)
+	}
 
 	var l ImportList
 	for i, res := range rl {

--- a/internal/meta/meta_rg.go
+++ b/internal/meta/meta_rg.go
@@ -55,7 +55,7 @@ func (meta *MetaResourceGroup) ListResource(ctx context.Context) (ImportList, er
 	}
 
 	log.Printf("[DEBUG] Azure Resource set map to TF resource set")
-	rl := rset.ToTFResources(meta.parallelism, meta.azureSDKCred, meta.azureSDKClientOpt)
+	rl := meta.GenTFResources(rset)
 
 	var l ImportList
 	for i, res := range rl {

--- a/internal/resourceset/azure_resource_set.go
+++ b/internal/resourceset/azure_resource_set.go
@@ -100,3 +100,14 @@ func (rset AzureResourceSet) ToTFResources(parallelism int, cred azcore.TokenCre
 
 	return tfresources
 }
+
+func (rset AzureResourceSet) ToAzAPIResources() (result []TFResource) {
+	for _, res := range rset.Resources {
+		result = append(result, TFResource{
+			AzureId: res.Id,
+			TFId:    res.Id.String(),
+			TFType:  "azapi_resource",
+		})
+	}
+	return
+}

--- a/internal/resourceset/azure_resource_set.go
+++ b/internal/resourceset/azure_resource_set.go
@@ -26,7 +26,7 @@ type PesudoResourceInfo struct {
 	TFId   string
 }
 
-func (rset AzureResourceSet) ToTFResources(parallelism int, cred azcore.TokenCredential, clientOpt arm.ClientOptions) []TFResource {
+func (rset AzureResourceSet) ToTFAzureRMResources(parallelism int, cred azcore.TokenCredential, clientOpt arm.ClientOptions) []TFResource {
 	tfresources := []TFResource{}
 
 	wp := workerpool.NewWorkPool(parallelism)
@@ -101,7 +101,7 @@ func (rset AzureResourceSet) ToTFResources(parallelism int, cred azcore.TokenCre
 	return tfresources
 }
 
-func (rset AzureResourceSet) ToAzAPIResources() (result []TFResource) {
+func (rset AzureResourceSet) ToTFAzAPIResources() (result []TFResource) {
 	for _, res := range rset.Resources {
 		result = append(result, TFResource{
 			AzureId: res.Id,

--- a/main.go
+++ b/main.go
@@ -30,12 +30,7 @@ import (
 
 	"github.com/Azure/aztfexport/internal"
 	"github.com/Azure/aztfexport/internal/ui"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	azlog "github.com/Azure/azure-sdk-for-go/sdk/azcore/log"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/urfave/cli/v2"
 )
 
@@ -477,7 +472,6 @@ func main() {
 
 					rg := c.Args().First()
 
-					// cred, clientOpt, err := buildAzureSDKCredAndClientOpt(flagset)
 					commonConfig, err := flagset.BuildCommonConfig()
 					if err != nil {
 						return err
@@ -510,7 +504,6 @@ func main() {
 
 					predicate := c.Args().First()
 
-					// cred, clientOpt, err := buildAzureSDKCredAndClientOpt(flagset)
 					commonConfig, err := flagset.BuildCommonConfig()
 					if err != nil {
 						return err
@@ -544,7 +537,6 @@ func main() {
 
 					mapFile := c.Args().First()
 
-					// cred, clientOpt, err := buildAzureSDKCredAndClientOpt(flagset)
 					commonConfig, err := flagset.BuildCommonConfig()
 					if err != nil {
 						return err
@@ -623,133 +615,6 @@ func initLog(path string, flagLevel string) error {
 		})
 	}
 	return nil
-}
-
-func initTelemetryClient(subscriptionId string) telemetry.Client {
-	cfg, err := cfgfile.GetConfig()
-	if err != nil {
-		return telemetry.NewNullClient()
-	}
-	enabled, installId := cfg.TelemetryEnabled, cfg.InstallationId
-	if !enabled {
-		return telemetry.NewNullClient()
-	}
-	if installId == "" {
-		uuid, err := uuid.NewV4()
-		if err == nil {
-			installId = uuid.String()
-		} else {
-			installId = "undefined"
-		}
-	}
-
-	sessionId := "undefined"
-	if uuid, err := uuid.NewV4(); err == nil {
-		sessionId = uuid.String()
-	}
-	return telemetry.NewAppInsight(subscriptionId, installId, sessionId)
-}
-
-// buildAzureSDKCredAndClientOpt builds the Azure SDK credential and client option from multiple sources (i.e. environment variables, MSI, Azure CLI).
-func buildAzureSDKCredAndClientOpt(fset FlagSet) (azcore.TokenCredential, *arm.ClientOptions, error) {
-	var cloudCfg cloud.Configuration
-	switch env := fset.flagEnv; strings.ToLower(env) {
-	case "public":
-		cloudCfg = cloud.AzurePublic
-	case "usgovernment":
-		cloudCfg = cloud.AzureGovernment
-	case "china":
-		cloudCfg = cloud.AzureChina
-	default:
-		return nil, nil, fmt.Errorf("unknown environment specified: %q", env)
-	}
-
-	// Maps the auth related environment variables used in the provider to what azidentity honors
-	if v, ok := os.LookupEnv("ARM_TENANT_ID"); ok {
-		// #nosec G104
-		os.Setenv("AZURE_TENANT_ID", v)
-	}
-	if v, ok := os.LookupEnv("ARM_CLIENT_ID"); ok {
-		// #nosec G104
-		os.Setenv("AZURE_CLIENT_ID", v)
-	}
-	if v, ok := os.LookupEnv("ARM_CLIENT_SECRET"); ok {
-		// #nosec G104
-		os.Setenv("AZURE_CLIENT_SECRET", v)
-	}
-	if v, ok := os.LookupEnv("ARM_CLIENT_CERTIFICATE_PATH"); ok {
-		// #nosec G104
-		os.Setenv("AZURE_CLIENT_CERTIFICATE_PATH", v)
-	}
-
-	clientOpt := &arm.ClientOptions{
-		ClientOptions: policy.ClientOptions{
-			Cloud: cloudCfg,
-			Telemetry: policy.TelemetryOptions{
-				ApplicationID: "aztfexport",
-				Disabled:      false,
-			},
-			Logging: policy.LogOptions{
-				IncludeBody: true,
-			},
-		},
-	}
-
-	tenantId := os.Getenv("ARM_TENANT_ID")
-	var (
-		cred azcore.TokenCredential
-		err  error
-	)
-	switch {
-	case fset.flagUseEnvironmentCred:
-		cred, err = azidentity.NewEnvironmentCredential(&azidentity.EnvironmentCredentialOptions{
-			ClientOptions: clientOpt.ClientOptions,
-		})
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to new Environment credential: %v", err)
-		}
-		return cred, clientOpt, nil
-	case fset.flagUseManagedIdentityCred:
-		cred, err = azidentity.NewManagedIdentityCredential(&azidentity.ManagedIdentityCredentialOptions{
-			ClientOptions: clientOpt.ClientOptions,
-		})
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to new Managed Identity credential: %v", err)
-		}
-		return cred, clientOpt, nil
-	case fset.flagUseAzureCLICred:
-		cred, err = azidentity.NewAzureCLICredential(&azidentity.AzureCLICredentialOptions{
-			TenantID: tenantId,
-		})
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to new Azure CLI credential: %v", err)
-		}
-		return cred, clientOpt, nil
-	case fset.flagUseOIDCCred:
-		cred, err = NewOidcCredential(&OidcCredentialOptions{
-			ClientOptions: clientOpt.ClientOptions,
-			TenantID:      tenantId,
-			ClientID:      os.Getenv("ARM_CLIENT_ID"),
-			RequestToken:  fset.flagOIDCRequestToken,
-			RequestUrl:    fset.flagOIDCRequestURL,
-			Token:         fset.flagOIDCToken,
-			TokenFilePath: fset.flagOIDCTokenFilePath,
-		})
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to new OIDC credential: %v", err)
-		}
-		return cred, clientOpt, nil
-	default:
-		opt := &azidentity.DefaultAzureCredentialOptions{
-			ClientOptions: clientOpt.ClientOptions,
-			TenantID:      tenantId,
-		}
-		cred, err := azidentity.NewDefaultAzureCredential(opt)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to new Default credential: %v", err)
-		}
-		return cred, clientOpt, nil
-	}
 }
 
 func subscriptionIdFromCLI() (string, error) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,6 +35,9 @@ type CommonConfig struct {
 	// DevProvider specifies whether users have configured the `dev_overrides` for the provider, which then uses a development provider built locally rather than using a version pinned provider from official Terraform registry.
 	// Meanwhile, it will also avoid running `terraform init` during `Init()` for the import directories to avoid caculating the provider hash and populating the lock file (See: https://developer.hashicorp.com/terraform/language/files/dependency-lock). Though the init for the output directory is still needed for initializing the backend.
 	DevProvider bool
+	// ProviderName specifies the provider Name. If this is not set, it will use `azurerm` for importing in order to be consistent with tfadd.
+	// Supported values: azurerm, azapi
+	ProviderName string
 	// ContinueOnError specifies whether continue the progress even hit an import error.
 	ContinueOnError bool
 	// BackendType specifies the Terraform backend type.


### PR DESCRIPTION
This PR is to add support for exporting to azapi provider.

1. Add a new argument to specify the provider to export to. Currently support `azapi`.
2. Extract building common config from `main.go` as it is repeated too many times.
3. Do not add dependency in the resource if the parent resource contains the sub-resources' id in its body. This is to prevent the circular dependencies in the generated configuration.