### PR TITLE
Update `tfadd` to make azapi export more useful & UI adpotion for azapi

### DIFF
--- a/command_before_func.go
+++ b/command_before_func.go
@@ -172,7 +172,7 @@ The output directory is not empty. Please choose one of actions below:
 			if err != nil {
 				return fmt.Errorf("loading terraform config: %v", err)
 			}
-			if azurecfg, ok := module.RequiredProviders["azurerm"]; ok {
+			if azurecfg, ok := module.RequiredProviders[fset.flagProviderName]; ok {
 				fset.flagProviderVersion = strings.Join(azurecfg.VersionConstraints, " ")
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/magodo/spinner v0.0.0-20220720073946-50f31b2dc5a6
 	github.com/magodo/terraform-client-go v0.0.0-20230323074119-02ceb732dd25
 	github.com/magodo/textinput v0.0.0-20210913072708-7d24f2b4b0c0
-	github.com/magodo/tfadd v0.10.1-0.20231024014800-2f2cdcd2fe1c
+	github.com/magodo/tfadd v0.10.1-0.20231025052212-d9c6bf90d0f2
 	github.com/magodo/tfmerge v0.0.0-20221214062955-f52e46d03402
 	github.com/magodo/tfstate v0.0.0-20220409052014-9b9568dda918
 	github.com/magodo/workerpool v0.0.0-20230119025400-40192d2716ea

--- a/go.sum
+++ b/go.sum
@@ -236,8 +236,8 @@ github.com/magodo/terraform-client-go v0.0.0-20230323074119-02ceb732dd25 h1:V4R1
 github.com/magodo/terraform-client-go v0.0.0-20230323074119-02ceb732dd25/go.mod h1:L12osIvZuDH0/UzrWn3+kiBRXDFTuoYaqF7UfTsbbQA=
 github.com/magodo/textinput v0.0.0-20210913072708-7d24f2b4b0c0 h1:aNtr4iNv/tex2t8W1u3scAoNHEnFlTKhNNHOpYStqbs=
 github.com/magodo/textinput v0.0.0-20210913072708-7d24f2b4b0c0/go.mod h1:MqYhNP+PC386Bjsx5piZe7T4vDm5QIPv8b1RU0prVnU=
-github.com/magodo/tfadd v0.10.1-0.20231024014800-2f2cdcd2fe1c h1:S6a0oeGahKw4u9Sq2mrOsViolpbCcTokf9IgWAQYXpE=
-github.com/magodo/tfadd v0.10.1-0.20231024014800-2f2cdcd2fe1c/go.mod h1:6W2btqbRymCIrUhOlqrBgr/CyCa6lzNvs6fypoveye0=
+github.com/magodo/tfadd v0.10.1-0.20231025052212-d9c6bf90d0f2 h1:B9LMnFVPXNF1R0iGOWivYYq1CNPl8V2DUG9QVnaCQmo=
+github.com/magodo/tfadd v0.10.1-0.20231025052212-d9c6bf90d0f2/go.mod h1:6W2btqbRymCIrUhOlqrBgr/CyCa6lzNvs6fypoveye0=
 github.com/magodo/tfmerge v0.0.0-20221214062955-f52e46d03402 h1:RyaR4VE7hoR9AyoVH414cpM8V63H4rLe2aZyKdoDV1w=
 github.com/magodo/tfmerge v0.0.0-20221214062955-f52e46d03402/go.mod h1:ssV++b4DH33rsD592bvpS4Peng3ZfdGNZbFgCDkCfj8=
 github.com/magodo/tfpluginschema v0.0.0-20220905090502-2d6a05ebaefd h1:L0kTduNwpx60EdBPYOVF9oUY7jdfZHIncvQN490qWd4=

--- a/internal/meta/meta_dummy.go
+++ b/internal/meta/meta_dummy.go
@@ -6,11 +6,16 @@ import (
 )
 
 type MetaGroupDummy struct {
-	rg string
+	rg           string
+	providerName string
 }
 
-func NewGroupMetaDummy(rg string) MetaGroupDummy {
-	return MetaGroupDummy{rg: rg}
+func NewGroupMetaDummy(rg string, providerName string) MetaGroupDummy {
+	return MetaGroupDummy{rg: rg, providerName: providerName}
+}
+
+func (m MetaGroupDummy) ProviderName() string {
+	return m.providerName
 }
 
 func (m MetaGroupDummy) Init(_ context.Context) error {

--- a/internal/run.go
+++ b/internal/run.go
@@ -17,7 +17,7 @@ import (
 )
 
 func BatchImport(ctx context.Context, cfg config.NonInteractiveModeConfig) error {
-	var c meta.Meta = internalmeta.NewGroupMetaDummy(cfg.ResourceGroupName)
+	var c meta.Meta = internalmeta.NewGroupMetaDummy(cfg.ResourceGroupName, cfg.ProviderName)
 	if !cfg.MockMeta {
 		var err error
 		c, err = meta.NewMeta(cfg.Config)

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -89,7 +89,7 @@ func newModel(ctx context.Context, cfg config.InteractiveModeConfig) (*model, er
 	s := spinner.NewModel()
 	s.Spinner = common.Spinner
 
-	var c meta.Meta = internalmeta.NewGroupMetaDummy(cfg.ResourceGroupName)
+	var c meta.Meta = internalmeta.NewGroupMetaDummy(cfg.ResourceGroupName, cfg.ProviderName)
 	if !cfg.MockMeta {
 		var err error
 		c, err = meta.NewMeta(cfg.Config)

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/magodo/armid"
 	"github.com/magodo/azlist/azlist"
+	"github.com/magodo/tfadd/providers/azapi"
 	"github.com/magodo/tfadd/providers/azurerm"
 
 	"github.com/Azure/aztfexport/internal"
@@ -153,7 +154,7 @@ func main() {
 		&cli.StringFlag{
 			Name:        "provider-version",
 			EnvVars:     []string{"AZTFEXPORT_PROVIDER_VERSION"},
-			Usage:       fmt.Sprintf("The provider version to use for importing. Defaults to %q for azurerm, defaults to the latest version for azapi", azurerm.ProviderSchemaInfo.Version),
+			Usage:       fmt.Sprintf("The provider version to use for importing. Defaults to %q for azurerm, %s for azapi", azurerm.ProviderSchemaInfo.Version, azapi.ProviderSchemaInfo.Version),
 			Destination: &flagset.flagProviderVersion,
 		},
 		&cli.StringFlag{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,7 +30,7 @@ type CommonConfig struct {
 	OutputDir string
 	// OutputFileNames specifies the output terraform filenames
 	OutputFileNames OutputFileNames
-	// ProviderVersion specifies the azurerm provider version used for importing. If this is not set, it will use `azurerm.ProviderSchemaInfo.Version` for importing in order to be consistent with tfadd.
+	// ProviderVersion specifies the provider version used for importing. If this is not set, it will use `{azurerm|azapi}.ProviderSchemaInfo.Version` for importing in order to be consistent with tfadd.
 	ProviderVersion string
 	// DevProvider specifies whether users have configured the `dev_overrides` for the provider, which then uses a development provider built locally rather than using a version pinned provider from official Terraform registry.
 	// Meanwhile, it will also avoid running `terraform init` during `Init()` for the import directories to avoid caculating the provider hash and populating the lock file (See: https://developer.hashicorp.com/terraform/language/files/dependency-lock). Though the init for the output directory is still needed for initializing the backend.
@@ -43,7 +43,7 @@ type CommonConfig struct {
 	BackendType string
 	// BackendConfig specifies an array of Terraform backend configs.
 	BackendConfig []string
-	// ProviderConfig specifies key value pairs that will be expanded to the terraform-provider-azurerm settings (i.e. `azurerm {}` block)
+	// ProviderConfig specifies key value pairs that will be expanded to the terraform-provider-{azurerm|azapi} settings (e.g. `azurerm {}` block)
 	// Currently, only the attributes (rather than blocks) are supported.
 	// This is not used directly by aztfexport as the provider configs can be set by environment variable already.
 	// While it is useful for module users that want support multi-users scenarios in one process (in which case changing env vars affect the whole process).


### PR DESCRIPTION
This PR updates `tfadd` to involve the special handling for `azapi`: https://github.com/magodo/tfadd/pull/7, where it keeps some useful properties always converted from state, even if they are O+C, for its "partial" mode.

Since now `azapi` config generation is bound to a specific version as `azurerm` doesn, the provider version's default value is now also bound to the one defined in `tfadd`.

Meanwhile, this PR fixes some issuse for interactive mode, to adpot for `azapi`.