### PR TITLE
Provider block existance check for azapi

### DIFF
--- a/internal/meta/base_meta.go
+++ b/internal/meta/base_meta.go
@@ -724,7 +724,7 @@ func (meta *baseMeta) initProvider(ctx context.Context) error {
 		return err
 	}
 
-	if module.ProviderConfigs["azurerm"] == nil {
+	if module.ProviderConfigs[meta.providerName] == nil {
 		log.Printf("[INFO] Output directory doesn't contain provider setting, create one then")
 		cfgFile := filepath.Join(meta.outdir, meta.outputFileNames.ProviderFileName)
 		// #nosec G306


### PR DESCRIPTION
Provider block existance check for azapi. Otherwise, append mode will failed to init as there will be multiple provider configurations.