### PR TITLE
Update the `ClientOptions.Telemetry.ApplicationID` to append the provider name, which is used in the `User-Agent` request header

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -251,7 +251,7 @@ func buildAzureSDKCredAndClientOpt(fset FlagSet) (azcore.TokenCredential, *arm.C
 		ClientOptions: policy.ClientOptions{
 			Cloud: cloudCfg,
 			Telemetry: policy.TelemetryOptions{
-				ApplicationID: "aztfexport",
+				ApplicationID: fmt.Sprintf("aztfexport(%s)", fset.flagProviderName),
 				Disabled:      false,
 			},
 			Logging: policy.LogOptions{


### PR DESCRIPTION
Update the `ClientOptions.Telemetry.ApplicationID` to append the provider name, which is used in the `User-Agent` request header