### PR TITLE
Provider initialization using the terraform-client-import updates to adopt for azapi

### DIFF
--- a/internal/meta/base_meta.go
+++ b/internal/meta/base_meta.go
@@ -580,11 +580,20 @@ func (meta *baseMeta) init_notf(ctx context.Context) error {
 		return fmt.Errorf("getting provider schema: %v", diags)
 	}
 
-	// Ensure "features" is always defined in the provider initConfig
-	initConfig, err := ctyjson.Unmarshal([]byte(`{"features": []}`), configschema.SchemaBlockImpliedType(schResp.Provider.Block))
-	if err != nil {
-		return fmt.Errorf("ctyjson unmarshal initial provider config")
+	var (
+		initConfig cty.Value
+		err        error
+	)
+	if meta.useAzAPI() {
+		initConfig, err = ctyjson.Unmarshal([]byte(`{}`), configschema.SchemaBlockImpliedType(schResp.Provider.Block))
+	} else {
+		// Ensure "features" is always defined in the provider initConfig
+		initConfig, err = ctyjson.Unmarshal([]byte(`{"features": []}`), configschema.SchemaBlockImpliedType(schResp.Provider.Block))
 	}
+	if err != nil {
+		return fmt.Errorf("ctyjson unmarshal initial provider config: %v", err)
+	}
+
 	providerConfig := initConfig.AsValueMap()
 
 	for k, v := range meta.providerConfig {

--- a/internal/meta/base_meta.go
+++ b/internal/meta/base_meta.go
@@ -580,16 +580,12 @@ func (meta *baseMeta) init_notf(ctx context.Context) error {
 		return fmt.Errorf("getting provider schema: %v", diags)
 	}
 
-	var (
-		initConfig cty.Value
-		err        error
-	)
-	if meta.useAzAPI() {
-		initConfig, err = ctyjson.Unmarshal([]byte(`{}`), configschema.SchemaBlockImpliedType(schResp.Provider.Block))
-	} else {
-		// Ensure "features" is always defined in the provider initConfig
-		initConfig, err = ctyjson.Unmarshal([]byte(`{"features": []}`), configschema.SchemaBlockImpliedType(schResp.Provider.Block))
+	providerCfg := "{}"
+	if !meta.useAzAPI() {
+		// Ensure "features" is always defined in the azurerm provider initConfig
+		providerCfg = `{"features": []}`
 	}
+	initConfig, err := ctyjson.Unmarshal([]byte(providerCfg), configschema.SchemaBlockImpliedType(schResp.Provider.Block))
 	if err != nil {
 		return fmt.Errorf("ctyjson unmarshal initial provider config: %v", err)
 	}


### PR DESCRIPTION
This PR fixes a missing corner case when exporting to azapi provider using an explicitly specified provider locally.

PS: This initialization step is not exposed for general use.