### PR TITLE
Fix cross RP parent-child dependency

### DIFF
--- a/internal/meta/config_info.go
+++ b/internal/meta/config_info.go
@@ -113,6 +113,7 @@ func (cfgs ConfigInfos) AddDependency() error {
 func (cfgs ConfigInfos) addParentChildDependency() {
 	for i, cfg := range cfgs {
 		parentId := cfg.AzureResourceID.Parent()
+
 		// This resource is either a root scope or a root scoped resource
 		if parentId == nil {
 			// Root scope: ignore as it has no parent
@@ -120,6 +121,9 @@ func (cfgs ConfigInfos) addParentChildDependency() {
 				continue
 			}
 			// Root scoped resource: use its parent scope as its parent
+			parentId = cfg.AzureResourceID.ParentScope()
+		} else if parentId.Parent() == nil {
+			// The cfg reosurce is the RP 1st level resource, we regard its parent scope as its parent
 			parentId = cfg.AzureResourceID.ParentScope()
 		}
 


### PR DESCRIPTION
In https://github.com/Azure/aztfexport/pull/455, the `armid` package is updated to include the change https://github.com/magodo/armid/commit/7d1b8afd6ee1bc67d75176eb652579ecd31cd6be, which requires adoption in `aztfexport` to keep the cross rp parent-child dependencies.

E.g.

Before #455, and with this RP. We can get below when exporting a RG contains ACR:

```hcl
resource "azurerm_container_registry" "res-1" {
  #...
  depends_on = [
    azurerm_resource_group.res-0,
  ]
}
```

But since #455 without this RP, we won't get the above `depends_on`.