### PR TITLE
Test telemetry app id be consistent as the non-test one

### DIFF
--- a/internal/test/resourcegroup/e2e_cases_test.go
+++ b/internal/test/resourcegroup/e2e_cases_test.go
@@ -70,6 +70,7 @@ func runCase(t *testing.T, d test.Data, c cases.Case) {
 				BackendType:          "local",
 				DevProvider:          true,
 				Parallelism:          10,
+				ProviderName:         "azurerm",
 			},
 			ResourceGroupName:   d.RandomRgName(),
 			ResourceNamePattern: "res-",

--- a/internal/test/utils.go
+++ b/internal/test/utils.go
@@ -79,7 +79,7 @@ func BuildCredAndClientOpt(t *testing.T) (azcore.TokenCredential, *arm.ClientOpt
 		ClientOptions: policy.ClientOptions{
 			Cloud: cloudCfg,
 			Telemetry: policy.TelemetryOptions{
-				ApplicationID: "aztfexport",
+				ApplicationID: "aztfexport(azurerm)",
 				Disabled:      false,
 			},
 			Logging: policy.LogOptions{


### PR DESCRIPTION
Makes test/non-test telemetry app id be of the same form `aztfexport(azurerm|azapi)`.