### PR TITLE
New option: `--generate-import-block` to allow users to select whether to generate the import.tf

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -42,6 +42,7 @@ type FlagSet struct {
 	flagGenerateMappingFile bool
 	flagHCLOnly             bool
 	flagModulePath          string
+	flagGenerateImportBlock bool
 
 	// common flags (auth)
 	flagUseEnvironmentCred     bool
@@ -142,6 +143,9 @@ func (flag FlagSet) DescribeCLI(mode string) string {
 	}
 	if flag.flagModulePath != "" {
 		args = append(args, "--module-path="+flag.flagModulePath)
+	}
+	if !flag.flagGenerateImportBlock {
+		args = append(args, "--generate-import-block=true")
 	}
 
 	if flag.flagUseEnvironmentCred {
@@ -352,6 +356,7 @@ func (f FlagSet) BuildCommonConfig() (config.CommonConfig, error) {
 		Parallelism:          f.flagParallelism,
 		HCLOnly:              f.flagHCLOnly,
 		ModulePath:           f.flagModulePath,
+		GenerateImportBlock:  f.flagGenerateImportBlock,
 		TelemetryClient:      initTelemetryClient(f.flagSubscriptionId),
 	}
 

--- a/internal/test/query/query_test.go
+++ b/internal/test/query/query_test.go
@@ -97,6 +97,7 @@ resource "azurerm_subnet" "test" {
 				BackendType:          "local",
 				DevProvider:          true,
 				Parallelism:          1,
+				ProviderName:         "azurerm",
 			},
 			ResourceNamePattern: "res-",
 			ARGPredicate:        fmt.Sprintf(`resourceGroup =~ "%s" and type =~ "microsoft.network/virtualnetworks"`, d.RandomRgName()),

--- a/internal/test/resmap/e2e_cases_test.go
+++ b/internal/test/resmap/e2e_cases_test.go
@@ -80,6 +80,7 @@ func runCase(t *testing.T, d test.Data, c cases.Case) {
 				BackendType:          "local",
 				DevProvider:          true,
 				Parallelism:          1,
+				ProviderName:         "azurerm",
 			},
 			MappingFile: mapFile,
 		},

--- a/internal/test/resource/e2e_cases_test.go
+++ b/internal/test/resource/e2e_cases_test.go
@@ -78,6 +78,7 @@ func runCase(t *testing.T, d test.Data, c cases.Case) {
 					BackendType:          "local",
 					DevProvider:          true,
 					Parallelism:          1,
+					ProviderName:         "azurerm",
 				},
 				ResourceId:     rctx.AzureId,
 				TFResourceName: fmt.Sprintf("res-%d", idx),

--- a/internal/test/resourcegroup/append_test.go
+++ b/internal/test/resourcegroup/append_test.go
@@ -91,6 +91,7 @@ resource "azurerm_resource_group" "test3" {
 				BackendType:          "local",
 				DevProvider:          true,
 				Parallelism:          1,
+				ProviderName:         "azurerm",
 			},
 			ResourceNamePattern: "t1",
 		},

--- a/internal/test/resourcegroup/hcl_only_test.go
+++ b/internal/test/resourcegroup/hcl_only_test.go
@@ -97,6 +97,7 @@ func runHCLOnly(t *testing.T, d test.Data, c cases.Case) {
 				DevProvider:          true,
 				Parallelism:          10,
 				HCLOnly:              true,
+				ProviderName:         "azurerm",
 			},
 			ResourceGroupName:   d.RandomRgName(),
 			ResourceNamePattern: "res-",

--- a/internal/test/resourcegroup/module_test.go
+++ b/internal/test/resourcegroup/module_test.go
@@ -118,6 +118,8 @@ module "sub-module" {
 				BackendType:          "local",
 				Parallelism:          1,
 				ModulePath:           "", // Import to the root module
+				ProviderName:         "azurerm",
+				GenerateImportBlock:  false,
 			},
 		},
 		PlainUI: true,

--- a/main.go
+++ b/main.go
@@ -229,6 +229,12 @@ func main() {
 			Usage:       `The path of the module (e.g. "module1.module2") where the resources will be imported and config generated. Note that only modules whose "source" is local path is supported. Defaults to the root module.`,
 			Destination: &flagset.flagModulePath,
 		},
+		&cli.BoolFlag{
+			Name:        "generate-import-block",
+			EnvVars:     []string{"AZTFEXPORT_GENERATE_IMPORT_BLOCK"},
+			Usage:       `Whether to generate the import.tf that contains the "import" blocks for the Terraform official plannable importing`,
+			Destination: &flagset.flagGenerateImportBlock,
+		},
 		&cli.StringFlag{
 			Name:        "log-path",
 			EnvVars:     []string{"AZTFEXPORT_LOG_PATH"},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -63,6 +63,8 @@ type CommonConfig struct {
 	TFClient tfclient.Client
 	// TelemetryClient is a client to send telemetry
 	TelemetryClient telemetry.Client
+	// GenerateImportBlock controls whether the export process ends up with a import.tf file that contains the "import" blocks
+	GenerateImportBlock bool
 }
 
 type Config struct {


### PR DESCRIPTION
Previously, this tool by default will generate the `import.tf` as long as the `terraform` >= v1.5.0. Whilst this behavior will cause error when append to a workspace as a submodule, as the `import.tf` is only allowed to appear at the root module.

This PR fixes this issue by introducing a new option --generate-import-block` to allow users to select whether to generate the `import.tf`.