### PR TITLE
Cfg: Add `ImportCallback` to allow caller inspect import status

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -22,6 +22,12 @@ jobs:
     steps:
       - name: Checkout Source
         uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.22
+
       - name: Run Gosec Security Scanner
         # This is due to https://github.com/securego/gosec/issues/1105
         # Per https://github.com/securego/gosec/issues/1105#issuecomment-1948225619, the issue occurs since 2.19.0.

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,7 +23,11 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@v3
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@2ae137abcf405533ad6e549e9363e58e4f6e8b7d
+        # This is due to https://github.com/securego/gosec/issues/1105
+        # Per https://github.com/securego/gosec/issues/1105#issuecomment-1948225619, the issue occurs since 2.19.0.
+        # The commit that updates the GH action to 2.19.0 is d13d7dac9b7e2b40e86be5b830d297816376f1db
+        # It's parent commit is 26e57d6b340778c2983cd61775bc7e8bb41d002a
+        uses: securego/gosec@26e57d6b340778c2983cd61775bc7e8bb41d002a
         with:
           args: './...'
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,7 +18,7 @@ jobs:
 
   gosec:
     name: gosec
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Source
         uses: actions/checkout@v3
@@ -30,7 +30,7 @@ jobs:
         # It's parent commit is 26e57d6b340778c2983cd61775bc7e8bb41d002a
         uses: securego/gosec@26e57d6b340778c2983cd61775bc7e8bb41d002a
         with:
-          args: './...'
+          args: '-tags -buildvcs=false ./...'
 
   depscheck:
     name: depscheck

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,15 +18,10 @@ jobs:
 
   gosec:
     name: gosec
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Source
         uses: actions/checkout@v3
-
-      - name: Set up Go
-        uses: actions/setup-go@v1
-        with:
-          go-version: 1.22
 
       - name: Run Gosec Security Scanner
         # This is due to https://github.com/securego/gosec/issues/1105

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -30,7 +30,7 @@ jobs:
         # It's parent commit is 26e57d6b340778c2983cd61775bc7e8bb41d002a
         uses: securego/gosec@26e57d6b340778c2983cd61775bc7e8bb41d002a
         with:
-          args: '-tags -buildvcs=false ./...'
+          args: './...'
 
   depscheck:
     name: depscheck

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,12 +1,30 @@
 package config
 
 import (
+	"github.com/Azure/aztfexport/internal/tfaddr"
 	"github.com/Azure/aztfexport/pkg/telemetry"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/magodo/armid"
 	"github.com/magodo/terraform-client-go/tfclient"
 	"github.com/zclconf/go-cty/cty"
 )
+
+type ImportItem struct {
+	// Azure resource Id
+	AzureResourceID armid.ResourceId
+
+	// The TF resource id
+	TFResourceId string
+
+	// Whether this azure resource failed to import into terraform (this might due to the TFResourceType doesn't match the resource)
+	ImportError error
+
+	// The terraform resource
+	TFAddr tfaddr.TFAddr
+}
+
+type ImportCallback func(total int, item ImportItem)
 
 type OutputFileNames struct {
 	// The filename for the generated "terraform.tf" (default)
@@ -52,6 +70,8 @@ type CommonConfig struct {
 	FullConfig bool
 	// Parallelism specifies the parallelism for the process
 	Parallelism int
+	// ImportCallback is a way to inspect each resource after being imported during ParallelImport
+	ImportCallback ImportCallback
 	// ModulePath specifies the path of the module (e.g. "module1.module2") where the resources will be imported and config generated.
 	// Note that only modules whose "source" is local path is supported. By default, it is the root module.
 	ModulePath string


### PR DESCRIPTION
Add `ImportCallback` in the `Config` to allow caller inspect import status. Though, this is not directly used by this `aztfexport` CLI tool, while it is for future usage.