### PR TITLE
Support full set of authentication configuration flags

### DIFF
--- a/auth_oidc.go
+++ b/auth_oidc.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 
@@ -21,28 +20,25 @@ type OidcCredential struct {
 	requestToken string
 	requestUrl   string
 
-	token         string
-	tokenFilePath string
+	token string
 
 	cred *azidentity.ClientAssertionCredential
 }
 
 type OidcCredentialOptions struct {
 	azcore.ClientOptions
-	TenantID      string
-	ClientID      string
-	RequestToken  string
-	RequestUrl    string
-	Token         string
-	TokenFilePath string
+	TenantID     string
+	ClientID     string
+	RequestToken string
+	RequestUrl   string
+	Token        string
 }
 
 func NewOidcCredential(options *OidcCredentialOptions) (*OidcCredential, error) {
 	w := &OidcCredential{
-		requestToken:  options.RequestToken,
-		requestUrl:    options.RequestUrl,
-		token:         options.Token,
-		tokenFilePath: options.TokenFilePath,
+		requestToken: options.RequestToken,
+		requestUrl:   options.RequestUrl,
+		token:        options.Token,
 	}
 
 	cred, err := azidentity.NewClientAssertionCredential(options.TenantID, options.ClientID, w.getAssertion, &azidentity.ClientAssertionCredentialOptions{ClientOptions: options.ClientOptions})
@@ -61,15 +57,6 @@ func (w *OidcCredential) GetToken(ctx context.Context, opts policy.TokenRequestO
 func (w *OidcCredential) getAssertion(ctx context.Context) (string, error) {
 	if w.token != "" {
 		return w.token, nil
-	}
-
-	if w.tokenFilePath != "" {
-		idTokenData, err := os.ReadFile(w.tokenFilePath)
-		if err != nil {
-			return "", fmt.Errorf("reading token file: %v", err)
-		}
-
-		return string(idTokenData), nil
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, w.requestUrl, http.NoBody)

--- a/command_before_func_test.go
+++ b/command_before_func_test.go
@@ -212,20 +212,6 @@ func TestCommondBeforeFunc(t *testing.T) {
 			},
 			err: "`--hcl-only` only works for local backend",
 		},
-		{
-			name: "--use-environment-cred works",
-			fset: FlagSet{
-				flagUseEnvironmentCred: true,
-			},
-		},
-		{
-			name: "--use-environment-cred with --use-azure-cli failed",
-			fset: FlagSet{
-				flagUseEnvironmentCred: true,
-				flagUseAzureCLICred:    true,
-			},
-			err: "only one of `--use-environment-cred`, `--use-managed-identity-cred`, `--use-azure-cli-cred` and `--use-oidc-cred` can be specified",
-		},
 	}
 
 	for _, tt := range cases {

--- a/cred.go
+++ b/cred.go
@@ -157,7 +157,7 @@ func NewDefaultAzureCredential(logger slog.Logger, opt *DefaultAzureCredentialOp
 
 	chain, err := azidentity.NewChainedTokenCredential(creds, nil)
 	if err != nil {
-		err = multierror.Append(err, fmt.Errorf("Errors collected so far: %v", err))
+		err = multierror.Append(err, fmt.Errorf("Errors from credential build tries: %v", errors))
 		return nil, err
 	}
 	return &DefaultAzureCredential{chain: chain}, nil

--- a/cred.go
+++ b/cred.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/Azure/aztfexport/pkg/config"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+)
+
+type DefaultAzureCredentialOptions struct {
+	AuthConfig               config.AuthConfig
+	ClientOptions            azcore.ClientOptions
+	DisableInstanceDiscovery bool
+	// Only applies to certificate credential
+	SendCertificateChain bool
+}
+
+// DefaultAzureCredential is a default credential chain for applications that will deploy to Azure.
+// It attempts to authenticate with each of these credential types, in the following order, stopping
+// when one provides a token:
+//   - [ClientSecretCredential]
+//   - [ClientCertificateCredential]
+//   - [OIDCCredential]
+//   - [ManagedIdentityCredential]
+//   - [AzureCLICredential]
+type DefaultAzureCredential struct {
+	chain *azidentity.ChainedTokenCredential
+}
+
+// NewDefaultAzureCredential creates a DefaultAzureCredential. Pass nil for options to accept defaults.
+func NewDefaultAzureCredential(logger slog.Logger, opt *DefaultAzureCredentialOptions) (*DefaultAzureCredential, error) {
+	var creds []azcore.TokenCredential
+
+	if opt == nil {
+		opt = &DefaultAzureCredentialOptions{}
+	}
+
+	logger.Info("Building credential via client secret")
+	if cred, err := azidentity.NewClientSecretCredential(
+		opt.AuthConfig.TenantID,
+		opt.AuthConfig.ClientID,
+		opt.AuthConfig.ClientSecret,
+		&azidentity.ClientSecretCredentialOptions{
+			ClientOptions:              opt.ClientOptions,
+			AdditionallyAllowedTenants: opt.AuthConfig.AuxiliaryTenantIDs,
+			DisableInstanceDiscovery:   opt.DisableInstanceDiscovery,
+		},
+	); err == nil {
+		logger.Info("Successfully built credential via client secret")
+		creds = append(creds, cred)
+	} else {
+		logger.Warn("Building credential via client secret failed", "error", err)
+	}
+
+	logger.Info("Building credential via client certificaite")
+	certs, key, err := azidentity.ParseCertificates([]byte(opt.AuthConfig.ClientCertificate), []byte(opt.AuthConfig.ClientCertificatePassword))
+	if err == nil {
+		if cred, err := azidentity.NewClientCertificateCredential(
+			opt.AuthConfig.TenantID,
+			opt.AuthConfig.ClientID,
+			certs,
+			key,
+			&azidentity.ClientCertificateCredentialOptions{
+				ClientOptions:              opt.ClientOptions,
+				AdditionallyAllowedTenants: opt.AuthConfig.AuxiliaryTenantIDs,
+				DisableInstanceDiscovery:   opt.DisableInstanceDiscovery,
+				SendCertificateChain:       opt.SendCertificateChain,
+			},
+		); err == nil {
+			logger.Info("Successfully built credential via client certificate")
+			creds = append(creds, cred)
+		} else {
+			logger.Warn("Building credential via client certificate failed", "error", err)
+		}
+	} else {
+		logger.Warn("Building credential via client secret failed", "error", fmt.Errorf(`failed to parse certificate: %v`, err))
+	}
+
+	if !opt.AuthConfig.UseOIDC {
+		logger.Info("OIDC credential skipped")
+	} else {
+		logger.Info("Building credential via OIDC")
+		if cred, err := NewOidcCredential(&OidcCredentialOptions{
+			ClientOptions: opt.ClientOptions,
+			TenantID:      opt.AuthConfig.TenantID,
+			ClientID:      opt.AuthConfig.ClientID,
+			RequestToken:  opt.AuthConfig.OIDCTokenRequestToken,
+			RequestUrl:    opt.AuthConfig.OIDCTokenRequestURL,
+			Token:         opt.AuthConfig.OIDCAssertionToken,
+		}); err == nil {
+			logger.Info("Successfully built credential via OIDC")
+			creds = append(creds, cred)
+		} else {
+			logger.Warn("Building credential via OIDC failed", "error", err)
+		}
+	}
+
+	if !opt.AuthConfig.UseManagedIdentity {
+		logger.Info("managed identity credential skipped")
+	} else {
+		logger.Info("Building credential via managed identity")
+		if cred, err := azidentity.NewManagedIdentityCredential(&azidentity.ManagedIdentityCredentialOptions{
+			ClientOptions: opt.ClientOptions,
+			ID:            azidentity.ClientID(opt.AuthConfig.ClientID),
+		}); err == nil {
+			logger.Info("Successfully built credential via managed identity")
+			creds = append(creds, cred)
+		} else {
+			logger.Warn("Building credential via managed identity failed", "error", err)
+		}
+	}
+
+	if !opt.AuthConfig.UseAzureCLI {
+		logger.Info("Azure CLI credential skipped")
+	} else {
+		logger.Info("Building credential via Azure CLI")
+		if cred, err := azidentity.NewAzureCLICredential(&azidentity.AzureCLICredentialOptions{
+			AdditionallyAllowedTenants: opt.AuthConfig.AuxiliaryTenantIDs,
+			TenantID:                   opt.AuthConfig.TenantID,
+		}); err == nil {
+			logger.Info("Successfully built credential via Azure CLI")
+			creds = append(creds, cred)
+		} else {
+			logger.Warn("Building credential via Azure CLI failed", "error", err)
+		}
+	}
+
+	chain, err := azidentity.NewChainedTokenCredential(creds, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &DefaultAzureCredential{chain: chain}, nil
+}
+
+// GetToken requests an access token from Azure Active Directory. This method is called automatically by Azure SDK clients.
+func (c *DefaultAzureCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return c.chain.GetToken(ctx, opts)
+}
+
+var _ azcore.TokenCredential = (*DefaultAzureCredential)(nil)

--- a/flag.go
+++ b/flag.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"log/slog"
@@ -276,7 +277,7 @@ func (f FlagSet) buildAuthConfig() (*config.AuthConfig, error) {
 		if err != nil {
 			return nil, fmt.Errorf("reading Client ID from file %q: %v", path, err)
 		}
-		clientId = strings.TrimSpace(string(b))
+		clientId = string(b)
 	}
 
 	clientSecret := f.flagClientSecret
@@ -285,16 +286,16 @@ func (f FlagSet) buildAuthConfig() (*config.AuthConfig, error) {
 		if err != nil {
 			return nil, fmt.Errorf("reading Client secret from file %q: %v", path, err)
 		}
-		clientSecret = strings.TrimSpace(string(b))
+		clientSecret = string(b)
 	}
 
-	clientCert := f.flagClientCertificate
+	clientCertEncoded := f.flagClientCertificate
 	if path := f.flagClientCertificatePath; path != "" {
 		b, err := os.ReadFile(path)
 		if err != nil {
 			return nil, fmt.Errorf("reading Client certificate from file %q: %v", path, err)
 		}
-		clientCert = strings.TrimSpace(string(b))
+		clientCertEncoded = base64.StdEncoding.EncodeToString(b)
 	}
 
 	oidcToken := f.flagOIDCToken
@@ -312,7 +313,7 @@ func (f FlagSet) buildAuthConfig() (*config.AuthConfig, error) {
 		AuxiliaryTenantIDs:        f.flagAuxiliaryTenantIds.Value(),
 		ClientID:                  clientId,
 		ClientSecret:              clientSecret,
-		ClientCertificate:         clientCert,
+		ClientCertificateEncoded:  clientCertEncoded,
 		ClientCertificatePassword: f.flagClientCertificatePassword,
 		OIDCTokenRequestToken:     f.flagOIDCRequestToken,
 		OIDCTokenRequestURL:       f.flagOIDCRequestURL,
@@ -343,7 +344,7 @@ func (f FlagSet) BuildCommonConfig() (config.CommonConfig, error) {
 			return config.CommonConfig{}, fmt.Errorf("creating log file %s: %v", path, err)
 		}
 
-		logger := slog.New(slog.NewTextHandler(f, &slog.HandlerOptions{Level: level}))
+		logger = slog.New(slog.NewTextHandler(f, &slog.HandlerOptions{Level: level}))
 
 		// Enable log for azure sdk
 		os.Setenv("AZURE_SDK_GO_LOGGING", "all") // #nosec G104

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/tidwall/sjson v1.2.5
 	github.com/urfave/cli/v2 v2.24.1
 	github.com/zclconf/go-cty v1.14.1
+	software.sslmate.com/src/go-pkcs12 v0.4.0
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/charmbracelet/lipgloss v0.5.0
 	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/hashicorp/go-hclog v1.6.3
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hc-install v0.7.0
 	github.com/hashicorp/hcl/v2 v2.17.0
@@ -103,7 +104,6 @@ require (
 	github.com/google/pprof v0.0.0-20211214055906-6f57359322fd // indirect
 	github.com/google/uuid v1.3.1 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.4.8 // indirect
 	github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f // indirect
 	github.com/hashicorp/terraform-plugin-go v0.14.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -406,3 +406,5 @@ gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+software.sslmate.com/src/go-pkcs12 v0.4.0 h1:H2g08FrTvSFKUj+D309j1DPfk5APnIdAQAB8aEykJ5k=
+software.sslmate.com/src/go-pkcs12 v0.4.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=

--- a/internal/meta/base_meta.go
+++ b/internal/meta/base_meta.go
@@ -207,6 +207,60 @@ func NewBaseMeta(cfg config.CommonConfig) (*baseMeta, error) {
 		}
 	}
 
+	// Merge the auth configs to the provider config, if the config not defined
+	providerConfig := cfg.ProviderConfig
+	if providerConfig == nil {
+		providerConfig = map[string]cty.Value{}
+	}
+
+	setIfNoExist := func(k string, v cty.Value) {
+		if _, ok := providerConfig[k]; !ok {
+			providerConfig[k] = v
+		}
+	}
+	if cfg.SubscriptionId != "" {
+		setIfNoExist("subscription_id", cty.StringVal(cfg.SubscriptionId))
+	}
+	if v := cfg.AuthConfig.Environment; v != "" {
+		setIfNoExist("environment", cty.StringVal(v))
+	}
+	if v := cfg.AuthConfig.TenantID; v != "" {
+		setIfNoExist("tenant_id", cty.StringVal(v))
+	}
+
+	if len(cfg.AuthConfig.AuxiliaryTenantIDs) != 0 {
+		var tenantIds []cty.Value
+		for _, id := range cfg.AuthConfig.AuxiliaryTenantIDs {
+			tenantIds = append(tenantIds, cty.StringVal(id))
+		}
+		setIfNoExist("auxiliary_tenant_ids", cty.ListVal(tenantIds))
+	}
+
+	if v := cfg.AuthConfig.ClientID; v != "" {
+		setIfNoExist("client_id", cty.StringVal(v))
+	}
+	if v := cfg.AuthConfig.ClientSecret; v != "" {
+		setIfNoExist("client_secret", cty.StringVal(v))
+	}
+	if v := cfg.AuthConfig.ClientCertificate; v != "" {
+		setIfNoExist("client_certificate", cty.StringVal(v))
+	}
+	if v := cfg.AuthConfig.ClientCertificatePassword; v != "" {
+		setIfNoExist("client_certificate_password", cty.StringVal(v))
+	}
+	if v := cfg.AuthConfig.OIDCTokenRequestToken; v != "" {
+		setIfNoExist("oidc_request_token", cty.StringVal(v))
+	}
+	if v := cfg.AuthConfig.OIDCTokenRequestURL; v != "" {
+		setIfNoExist("oidc_request_url", cty.StringVal(v))
+	}
+	if v := cfg.AuthConfig.OIDCAssertionToken; v != "" {
+		setIfNoExist("oidc_token", cty.StringVal(v))
+	}
+	setIfNoExist("use_msi", cty.BoolVal(cfg.AuthConfig.UseManagedIdentity))
+	setIfNoExist("use_cli", cty.BoolVal(cfg.AuthConfig.UseAzureCLI))
+	setIfNoExist("use_oidc", cty.BoolVal(cfg.AuthConfig.UseOIDC))
+
 	meta := &baseMeta{
 		logger:             cfg.Logger,
 		subscriptionId:     cfg.SubscriptionId,
@@ -219,7 +273,7 @@ func NewBaseMeta(cfg config.CommonConfig) (*baseMeta, error) {
 		devProvider:        cfg.DevProvider,
 		backendType:        cfg.BackendType,
 		backendConfig:      cfg.BackendConfig,
-		providerConfig:     cfg.ProviderConfig,
+		providerConfig:     providerConfig,
 		providerName:       cfg.ProviderName,
 		fullConfig:         cfg.FullConfig,
 		parallelism:        cfg.Parallelism,
@@ -580,14 +634,15 @@ func (meta *baseMeta) buildTerraformConfig(backendType string) string {
 func (meta *baseMeta) buildProviderConfig() string {
 	f := hclwrite.NewEmptyFile()
 
+	var body *hclwrite.Body
 	if meta.useAzAPI() {
-		f.Body().AppendNewBlock("provider", []string{"azapi"}).Body()
+		body = f.Body().AppendNewBlock("provider", []string{"azapi"}).Body()
 	} else {
-		body := f.Body().AppendNewBlock("provider", []string{"azurerm"}).Body()
+		body = f.Body().AppendNewBlock("provider", []string{"azurerm"}).Body()
 		body.AppendNewBlock("features", nil)
-		for k, v := range meta.providerConfig {
-			body.SetAttributeValue(k, v)
-		}
+	}
+	for k, v := range meta.providerConfig {
+		body.SetAttributeValue(k, v)
 	}
 	return string(f.Bytes())
 }

--- a/main.go
+++ b/main.go
@@ -262,13 +262,13 @@ func main() {
 		&cli.StringFlag{
 			Name:        "client-certificate",
 			EnvVars:     []string{"AZTFEXPORT_CLIENT_CERTIFICATE", "ARM_CLIENT_CERTIFICATE"},
-			Usage:       "The Azure client certificate",
+			Usage:       "A base64-encoded PKCS#12 bundle to be used as the client certificate for authentication",
 			Destination: &flagset.flagClientCertificate,
 		},
 		&cli.StringFlag{
 			Name:        "client-certificate-path",
 			EnvVars:     []string{"AZTFEXPORT_CLIENT_CERTIFICATE_PATH", "ARM_CLIENT_CERTIFICATE_PATH"},
-			Usage:       "The Azure client certificate file path",
+			Usage:       "The path to the Client Certificate (PKCS#12) associated with the Service Principal which should be used",
 			Destination: &flagset.flagClientCertificatePath,
 		},
 		&cli.StringFlag{

--- a/main.go
+++ b/main.go
@@ -93,16 +93,7 @@ func prepareConfigFile(ctx *cli.Context) error {
 func main() {
 	commonFlags := []cli.Flag{
 		&cli.StringFlag{
-			Name: "env",
-			// Honor the "ARM_ENVIRONMENT" as is used by the provider, for easier use.
-			EnvVars:     []string{"AZTFEXPORT_ENV", "ARM_ENVIRONMENT"},
-			Usage:       `The cloud environment, can be one of "public", "usgovernment" and "china"`,
-			Destination: &flagset.flagEnv,
-			Value:       "public",
-		},
-		&cli.StringFlag{
-			Name: "subscription-id",
-			// Honor the "ARM_SUBSCRIPTION_ID" as is used by the provider, for easier use.
+			Name:        "subscription-id",
 			EnvVars:     []string{"AZTFEXPORT_SUBSCRIPTION_ID", "ARM_SUBSCRIPTION_ID"},
 			Aliases:     []string{"s"},
 			Usage:       "The subscription id",
@@ -237,29 +228,66 @@ func main() {
 		},
 
 		// Common flags (auth)
-		&cli.BoolFlag{
-			Name:        "use-environment-cred",
-			EnvVars:     []string{"AZTFEXPORT_USE_ENVIRONMENT_CRED"},
-			Usage:       "Explicitly use the environment variables to do authentication",
-			Destination: &flagset.flagUseEnvironmentCred,
+		&cli.StringFlag{
+			Name:        "env",
+			EnvVars:     []string{"AZTFEXPORT_ENV", "ARM_ENVIRONMENT"},
+			Usage:       `The cloud environment, can be one of "public", "usgovernment" and "china"`,
+			Destination: &flagset.flagEnv,
+			Value:       "public",
 		},
-		&cli.BoolFlag{
-			Name:        "use-managed-identity-cred",
-			EnvVars:     []string{"AZTFEXPORT_USE_MANAGED_IDENTITY_CRED"},
-			Usage:       "Explicitly use the managed identity that is provided by the Azure host to do authentication",
-			Destination: &flagset.flagUseManagedIdentityCred,
+		&cli.StringFlag{
+			Name:        "tenant-id",
+			EnvVars:     []string{"AZTFEXPORT_TENANT_ID", "ARM_TENANT_ID"},
+			Usage:       "The Azure tenant id",
+			Destination: &flagset.flagTenantId,
 		},
-		&cli.BoolFlag{
-			Name:        "use-azure-cli-cred",
-			EnvVars:     []string{"AZTFEXPORT_USE_AZURE_CLI_CRED"},
-			Usage:       "Explicitly use the Azure CLI to do authentication",
-			Destination: &flagset.flagUseAzureCLICred,
+		&cli.StringSliceFlag{
+			Name:        "auxiliary-tenant-ids",
+			EnvVars:     []string{"AZTFEXPORT_AUXILIARY_TENANT_IDS", "ARM_AUXILIARY_TENANT_IDS"},
+			Usage:       "The Azure auxiliary tenant ids (comma separated)",
+			Destination: &flagset.flagAuxiliaryTenantIds,
 		},
-		&cli.BoolFlag{
-			Name:        "use-oidc-cred",
-			EnvVars:     []string{"AZTFEXPORT_USE_OIDC_CRED"},
-			Usage:       "Explicitly use the OIDC to do authentication",
-			Destination: &flagset.flagUseOIDCCred,
+		&cli.StringFlag{
+			Name:        "client-id",
+			EnvVars:     []string{"AZTFEXPORT_CLIENT_ID", "ARM_CLIENT_ID"},
+			Usage:       "The Azure client id",
+			Destination: &flagset.flagClientId,
+		},
+		&cli.StringFlag{
+			Name:        "client-id-file-path",
+			EnvVars:     []string{"AZTFEXPORT_CLIENT_ID_FILE_PATH", "ARM_CLIENT_ID_FILE_PATH"},
+			Usage:       "The Azure client id file path",
+			Destination: &flagset.flagClientIdFilePath,
+		},
+		&cli.StringFlag{
+			Name:        "client-certificate",
+			EnvVars:     []string{"AZTFEXPORT_CLIENT_CERTIFICATE", "ARM_CLIENT_CERTIFICATE"},
+			Usage:       "The Azure client certificate",
+			Destination: &flagset.flagClientCertificate,
+		},
+		&cli.StringFlag{
+			Name:        "client-certificate-path",
+			EnvVars:     []string{"AZTFEXPORT_CLIENT_CERTIFICATE_PATH", "ARM_CLIENT_CERTIFICATE_PATH"},
+			Usage:       "The Azure client certificate file path",
+			Destination: &flagset.flagClientCertificatePath,
+		},
+		&cli.StringFlag{
+			Name:        "client-certificate-password",
+			EnvVars:     []string{"AZTFEXPORT_CLIENT_CERTIFICATE_PASSWORD", "ARM_CLIENT_CERTIFICATE_PASSWORD"},
+			Usage:       "The password associated with the Client Certificate",
+			Destination: &flagset.flagClientCertificatePassword,
+		},
+		&cli.StringFlag{
+			Name:        "client-secret",
+			EnvVars:     []string{"AZTFEXPORT_CLIENT_SECRET", "ARM_CLIENT_SECRET"},
+			Usage:       "The Azure client secret",
+			Destination: &flagset.flagClientSecret,
+		},
+		&cli.StringFlag{
+			Name:        "client-secret-file-path",
+			EnvVars:     []string{"AZTFEXPORT_CLIENT_SECRET_FILE_PATH", "ARM_CLIENT_SECRET_FILE_PATH"},
+			Usage:       "The Azure client secret file path",
+			Destination: &flagset.flagClientSecretFilePath,
 		},
 		&cli.StringFlag{
 			Name:        "oidc-request-token",
@@ -284,6 +312,27 @@ func main() {
 			EnvVars:     []string{"AZTFEXPORT_OIDC_TOKEN", "ARM_OIDC_TOKEN"},
 			Usage:       "The ID token when authenticating using OIDC",
 			Destination: &flagset.flagOIDCToken,
+		},
+		&cli.BoolFlag{
+			Name:        "use-managed-identity-cred",
+			EnvVars:     []string{"AZTFEXPORT_USE_MANAGED_IDENTITY_CRED", "ARM_USE_MSI"},
+			Usage:       "Explicitly use the managed identity that is provided by the Azure host to do authentication",
+			Destination: &flagset.flagUseManagedIdentityCred,
+			Value:       false,
+		},
+		&cli.BoolFlag{
+			Name:        "use-azure-cli-cred",
+			EnvVars:     []string{"AZTFEXPORT_USE_AZURE_CLI_CRED", "ARM_USE_CLI"},
+			Usage:       "Explicitly use the Azure CLI to do authentication",
+			Destination: &flagset.flagUseAzureCLICred,
+			Value:       true,
+		},
+		&cli.BoolFlag{
+			Name:        "use-oidc-cred",
+			EnvVars:     []string{"AZTFEXPORT_USE_OIDC_CRED", "ARM_USE_OIDC"},
+			Usage:       "Explicitly use the OIDC to do authentication",
+			Destination: &flagset.flagUseOIDCCred,
+			Value:       false,
 		},
 
 		// Hidden flags

--- a/pkg/config/auth_config.go
+++ b/pkg/config/auth_config.go
@@ -1,0 +1,20 @@
+package config
+
+type AuthConfig struct {
+	Environment        string
+	TenantID           string
+	AuxiliaryTenantIDs []string
+
+	ClientID                  string
+	ClientSecret              string
+	ClientCertificate         string
+	ClientCertificatePassword string
+
+	OIDCTokenRequestToken string
+	OIDCTokenRequestURL   string
+	OIDCAssertionToken    string
+
+	UseAzureCLI        bool
+	UseManagedIdentity bool
+	UseOIDC            bool
+}

--- a/pkg/config/auth_config.go
+++ b/pkg/config/auth_config.go
@@ -7,7 +7,7 @@ type AuthConfig struct {
 
 	ClientID                  string
 	ClientSecret              string
-	ClientCertificate         string
+	ClientCertificateEncoded  string
 	ClientCertificatePassword string
 
 	OIDCTokenRequestToken string

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -42,6 +42,9 @@ type OutputFileNames struct {
 
 type CommonConfig struct {
 	Logger *slog.Logger
+	// AuthConfig specifies the authentication config for provider
+	// This doesn't impact the auth of the tool itself (e.g. listing resources), which is controlled by AzureSDKCredential field.
+	AuthConfig AuthConfig
 	// SubscriptionId specifies the user's Azure subscription id.
 	SubscriptionId string
 	// AzureSDKCredential specifies the Azure SDK token credential


### PR DESCRIPTION
Previously, there are some (though incomplete) authentication related flags, e.g. `--env`, `--use-azure-cli-cred`, these flags only affect the behavior of the `aztfexport` (e.g. listing resources), but won't be passed through to the providers. The providers' behaviors are only affected by either the `-provider-config` flag or by the environment of their owns.

The reason was there are a bunch of provider level properties (currently there are two providers). It would be a mass if we wrap all these flags and provide a bunch of flags back to users, and probably mentioning which set of flags are only usable for `azurerm` provider, and which are only for `azapi`.

However for the standview of the authentication, this separation brings a burden to users who will now need to take care of the two parts: `aztfexport` and the provider. It would be much easier for them to regard the both as a whole in terms of authentication. By reviewing the authentication flags between `azurerm` and `azapi`, they are actually quite the same. Based on this, we created this PR to wrap and expose all these authentication related flags, which will affect both the `aztfexport` and the providers.

## Changes

The new flags (or existing flags but now passed to providers) are listed below:

- `env`
- `tenant-id`
- `auxiliary-tenant-ids`
- `client-id`
- `client-id-file-path`
- `client-certificate`
- `client-certificate-path`
- `client-certificate-password`
- `client-secret`
- `client-secret-file-path`
- `oidc-request-token`
- `oidc-request-url`
- `oidc-token`
- `oidc-token-file-path`
- `use-managed-identity-cred` (defaults to false)
- `use-azure-cli-cred` (defaults to true)
- `use-oidc-cred` (defaults to false)

Note that the flags above are following the naming convention as the [`azurerm` provider](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs). All of them are configurable via environment variables as well, which include the same env var as is defined in the `azurerm` provider.

The default authentication of the `aztfexport` will attempt to authenticate with each of the credential types, in the following order, stopping when one provides a token:

- Client secret
- Client certificate
- OIDC
- Managed identity
- Azure CLI

If one or more `use-xxx-cred` is not true, then that credential type will be skipped. This behavior is the same as the provider. This changes the old behavior where when any `use-xxx-cred` is specified, it will only use that credential type exclusively. Also note that the old flag `use-environment-cred` is now removed.

The last thing to call out is that the priority of these new auth flags have lower priority than what is defined in the `provider-config`, which means users can override any auth config for the provider in the `provider-config`. This makes it possible for users to use different credential types between the `aztfexport` and the provider.

## Tests

With TF
---

- [x] Az CLI implicit sub
- [x] Az CLI explicit sub
- [x] (usgov) Az CLI implicit sub
- [x] Env var (client secret)
- [x] client secret
- [x] client secret path
- [x] client cert
- [x] client cert path
- [x] MSI
- [x] OIDC


Without TF
---

- [x] Az CLI implicit sub
- [x] Az CLI explicit sub
- [x] (usgov) Az CLI implicit sub

## References

Fix #540