### PR TITLE
Add `Set[Pre|Post]ImportHook` to BaseMeta interface

### DIFF
--- a/internal/meta/base_meta.go
+++ b/internal/meta/base_meta.go
@@ -75,6 +75,9 @@ type BaseMeta interface {
 	// CleanUpWorkspace is a weired method that is only meant to be used internally by aztfexport, which under the hood will remove everything in the output directory, except the generated TF config.
 	// This method does nothing if HCLOnly in the Config is not set.
 	CleanUpWorkspace(ctx context.Context) error
+
+	SetPreImportHook(config.ImportCallback)
+	SetPostImportHook(config.ImportCallback)
 }
 
 var _ BaseMeta = &baseMeta{}
@@ -530,6 +533,14 @@ func (meta baseMeta) CleanUpWorkspace(_ context.Context) error {
 	}
 
 	return nil
+}
+
+func (meta *baseMeta) SetPreImportHook(cb config.ImportCallback) {
+	meta.preImportHook = cb
+}
+
+func (meta *baseMeta) SetPostImportHook(cb config.ImportCallback) {
+	meta.postImportHook = cb
 }
 
 func (meta baseMeta) generateCfg(ctx context.Context, l ImportList, cfgTrans ...TFConfigTransformer) error {

--- a/internal/meta/base_meta.go
+++ b/internal/meta/base_meta.go
@@ -337,11 +337,11 @@ func (meta *baseMeta) ParallelImport(ctx context.Context, items []*ImportItem) e
 				}
 				startTime := time.Now()
 				if meta.preImportHook != nil {
-					meta.preImportHook(startTime, total, iitem)
+					meta.preImportHook(startTime, iitem)
 				}
 				meta.importItem(ctx, item, i)
 				if meta.postImportHook != nil {
-					meta.postImportHook(startTime, total, iitem)
+					meta.postImportHook(startTime, iitem)
 				}
 			}
 			return i, nil

--- a/internal/meta/meta_dummy.go
+++ b/internal/meta/meta_dummy.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"log/slog"
 	"time"
+
+	"github.com/Azure/aztfexport/pkg/config"
 )
 
 type MetaGroupDummy struct {
@@ -12,8 +14,8 @@ type MetaGroupDummy struct {
 	providerName string
 }
 
-func NewGroupMetaDummy(rg string, providerName string) MetaGroupDummy {
-	return MetaGroupDummy{rg: rg, providerName: providerName}
+func NewGroupMetaDummy(rg string, providerName string) *MetaGroupDummy {
+	return &MetaGroupDummy{rg: rg, providerName: providerName}
 }
 
 func (m MetaGroupDummy) Logger() *slog.Logger {
@@ -95,4 +97,10 @@ func (m MetaGroupDummy) ExportSkippedResources(_ context.Context, l ImportList) 
 func (m MetaGroupDummy) CleanUpWorkspace(_ context.Context) error {
 	time.Sleep(500 * time.Millisecond)
 	return nil
+}
+
+func (meta *MetaGroupDummy) SetPreImportHook(cb config.ImportCallback) {
+}
+
+func (meta *MetaGroupDummy) SetPostImportHook(cb config.ImportCallback) {
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,7 +27,7 @@ type ImportItem struct {
 	TFAddr tfaddr.TFAddr
 }
 
-type ImportCallback func(startTime time.Time, total int, item ImportItem)
+type ImportCallback func(startTime time.Time, item ImportItem)
 
 type OutputFileNames struct {
 	// The filename for the generated "terraform.tf" (default)

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -3,6 +3,7 @@ package meta
 import (
 	"context"
 	"fmt"
+
 	"github.com/Azure/aztfexport/internal/meta"
 	"github.com/Azure/aztfexport/pkg/config"
 )


### PR DESCRIPTION
This makes meta users to firstly import resources, then define the hook functions.