### PR TITLE
New option: `-mask-sensitive` to allow masking sensitive attributes

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -35,6 +35,7 @@ type FlagSet struct {
 	flagBackendType         string
 	flagBackendConfig       cli.StringSlice
 	flagFullConfig          bool
+	flagMaskSensitive       bool
 	flagParallelism         int
 	flagContinue            bool
 	flagNonInteractive      bool
@@ -132,6 +133,9 @@ func (flag FlagSet) DescribeCLI(mode string) string {
 	}
 	if flag.flagFullConfig {
 		args = append(args, "--full-properties=true")
+	}
+	if flag.flagMaskSensitive {
+		args = append(args, "--mask-sensitive=true")
 	}
 	if flag.flagParallelism != 0 {
 		args = append(args, fmt.Sprintf("--parallelism=%d", flag.flagParallelism))
@@ -409,6 +413,7 @@ func (f FlagSet) BuildCommonConfig() (config.CommonConfig, error) {
 		BackendType:          f.flagBackendType,
 		BackendConfig:        f.flagBackendConfig.Value(),
 		FullConfig:           f.flagFullConfig,
+		MaskSensitive:        f.flagMaskSensitive,
 		Parallelism:          f.flagParallelism,
 		HCLOnly:              f.flagHCLOnly,
 		ModulePath:           f.flagModulePath,

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/magodo/spinner v0.0.0-20240524082745-3a2305db1bdc
 	github.com/magodo/terraform-client-go v0.0.0-20230323074119-02ceb732dd25
 	github.com/magodo/textinput v0.0.0-20210913072708-7d24f2b4b0c0
-	github.com/magodo/tfadd v0.10.1-0.20240412023810-79ace00fe84d
+	github.com/magodo/tfadd v0.10.1-0.20240809033926-59efddadfd95
 	github.com/magodo/tfmerge v0.0.0-20221214062955-f52e46d03402
 	github.com/magodo/tfstate v0.0.0-20220409052014-9b9568dda918
 	github.com/magodo/workerpool v0.0.0-20240524082508-11838001bc35

--- a/go.sum
+++ b/go.sum
@@ -241,8 +241,8 @@ github.com/magodo/terraform-client-go v0.0.0-20230323074119-02ceb732dd25 h1:V4R1
 github.com/magodo/terraform-client-go v0.0.0-20230323074119-02ceb732dd25/go.mod h1:L12osIvZuDH0/UzrWn3+kiBRXDFTuoYaqF7UfTsbbQA=
 github.com/magodo/textinput v0.0.0-20210913072708-7d24f2b4b0c0 h1:aNtr4iNv/tex2t8W1u3scAoNHEnFlTKhNNHOpYStqbs=
 github.com/magodo/textinput v0.0.0-20210913072708-7d24f2b4b0c0/go.mod h1:MqYhNP+PC386Bjsx5piZe7T4vDm5QIPv8b1RU0prVnU=
-github.com/magodo/tfadd v0.10.1-0.20240412023810-79ace00fe84d h1:NPzZgU+4udgbPuGmwqXuxgdK7f8y86GydHHlXw5KSk0=
-github.com/magodo/tfadd v0.10.1-0.20240412023810-79ace00fe84d/go.mod h1:6W2btqbRymCIrUhOlqrBgr/CyCa6lzNvs6fypoveye0=
+github.com/magodo/tfadd v0.10.1-0.20240809033926-59efddadfd95 h1:940RtdDfXxJu0AUL0jFw8rMIRcUsOxDVp2sWg41YIlc=
+github.com/magodo/tfadd v0.10.1-0.20240809033926-59efddadfd95/go.mod h1:6W2btqbRymCIrUhOlqrBgr/CyCa6lzNvs6fypoveye0=
 github.com/magodo/tfmerge v0.0.0-20221214062955-f52e46d03402 h1:RyaR4VE7hoR9AyoVH414cpM8V63H4rLe2aZyKdoDV1w=
 github.com/magodo/tfmerge v0.0.0-20221214062955-f52e46d03402/go.mod h1:ssV++b4DH33rsD592bvpS4Peng3ZfdGNZbFgCDkCfj8=
 github.com/magodo/tfpluginschema v0.0.0-20220905090502-2d6a05ebaefd h1:L0kTduNwpx60EdBPYOVF9oUY7jdfZHIncvQN490qWd4=

--- a/main.go
+++ b/main.go
@@ -161,6 +161,13 @@ func main() {
 			Value:       false,
 			Destination: &flagset.flagFullConfig,
 		},
+		&cli.BoolFlag{
+			Name:        "mask-sensitive",
+			EnvVars:     []string{"AZTFEXPORT_MASK_SENSITIVE"},
+			Usage:       "Mask sensitive attributes in the Terraform configuration. This may require manual modifications to produce a valid config",
+			Value:       false,
+			Destination: &flagset.flagMaskSensitive,
+		},
 		&cli.IntFlag{
 			Name:        "parallelism",
 			EnvVars:     []string{"AZTFEXPORT_PARALLELISM"},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -75,6 +75,8 @@ type CommonConfig struct {
 	ProviderConfig map[string]cty.Value
 	// FullConfig specifies whether to export all (non computed-only) Terarform properties when generating TF configs.
 	FullConfig bool
+	// MaskSensitive specifies whether to mask sensitive attributes when generating TF configs.
+	MaskSensitive bool
 	// Parallelism specifies the parallelism for the process
 	Parallelism int
 	// PreImportHook is called before each resource is imported during ParallelImport


### PR DESCRIPTION
This PR adds new option `-mask-sensitive` to allow masking sensitive attributes. The masking is done by generating the zero value of that attribute, with a comment stating the reason. In non-full mode, those value will be trimed from the configuration, as they are of the zero values. While in the full mode, they are kept with the zero value + comments.