### PR TITLE
Resource mode supports multiple resources

### DIFF
--- a/command_before_func.go
+++ b/command_before_func.go
@@ -11,8 +11,8 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func commandBeforeFunc(fset *FlagSet) func(ctx *cli.Context) error {
-	return func(_ *cli.Context) error {
+func commandBeforeFunc(fset *FlagSet, mode Mode) func(ctx *cli.Context) error {
+	return func(ctx *cli.Context) error {
 		// Common flags check
 		if fset.flagAppend {
 			if fset.flagOverwrite {
@@ -101,6 +101,19 @@ func commandBeforeFunc(fset *FlagSet) func(ctx *cli.Context) error {
 			},
 		}); err != nil {
 			return err
+		}
+
+		// Mode specific flags check
+		switch mode {
+		case ModeResource:
+			if ctx.Args().Len() > 1 || (ctx.Args().Len() == 1 && strings.HasPrefix(ctx.Args().First(), "@")) {
+				if fset.flagResType != "" {
+					return fmt.Errorf("`--type` can't be specified for multi-resource mode")
+				}
+				if fset.flagResName != "" {
+					return fmt.Errorf("`--name` can't be specified for multi-resource mode")
+				}
+			}
 		}
 
 		// Initialize output directory

--- a/command_before_func_test.go
+++ b/command_before_func_test.go
@@ -226,7 +226,7 @@ func TestCommondBeforeFunc(t *testing.T) {
 				tt.fset.flagSubscriptionId = "test"
 			}
 
-			err := commandBeforeFunc(&tt.fset)(nil)
+			err := commandBeforeFunc(&tt.fset, "")(nil)
 			if tt.err == "" {
 				require.NoError(t, err)
 				if tt.postCheck != nil {

--- a/flag.go
+++ b/flag.go
@@ -74,8 +74,9 @@ type FlagSet struct {
 	// Subcommand specific flags
 	//
 	// res:
-	// flagResName
-	// flagResType
+	// flagResName (for single resource)
+	// flagResType (for single resource)
+	// flagPattern (for multi resources)
 	//
 	// rg:
 	// flagPattern
@@ -94,18 +95,20 @@ type FlagSet struct {
 	flagIncludeResourceGroup  bool
 }
 
+type Mode string
+
 const (
-	ModeResource      = "resource"
-	ModeResourceGroup = "resource-group"
-	ModeQuery         = "query"
-	ModeMappingFile   = "mapping-file"
+	ModeResource      Mode = "resource"
+	ModeResourceGroup Mode = "resource-group"
+	ModeQuery         Mode = "query"
+	ModeMappingFile   Mode = "mapping-file"
 )
 
 // DescribeCLI construct a description of the CLI based on the flag set and the specified mode.
 // The main reason is to record the usage of some "interesting" options in the telemetry.
 // Note that only insensitive values are recorded (i.e. subscription id, resource id, etc are not recorded)
-func (flag FlagSet) DescribeCLI(mode string) string {
-	args := []string{mode}
+func (flag FlagSet) DescribeCLI(mode Mode) string {
+	args := []string{string(mode)}
 
 	// The following flags are skipped eiter not interesting, or might contain sensitive info:
 	// - flagOutputDir
@@ -224,6 +227,9 @@ func (flag FlagSet) DescribeCLI(mode string) string {
 		}
 		if flag.flagResType != "" {
 			args = append(args, "--type="+flag.flagResType)
+		}
+		if flag.flagPattern != "" {
+			args = append(args, "--name-pattern="+flag.flagPattern)
 		}
 	case ModeResourceGroup:
 		if flag.flagPattern != "" {

--- a/internal/test/cases/case_vnet.go
+++ b/internal/test/cases/case_vnet.go
@@ -1,0 +1,85 @@
+package cases
+
+import (
+	"fmt"
+
+	"github.com/Azure/aztfexport/internal/resmap"
+	"github.com/Azure/aztfexport/internal/test"
+)
+
+var _ Case = CaseVnet{}
+
+type CaseVnet struct{}
+
+func (CaseVnet) Tpl(d test.Data) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+resource "azurerm_resource_group" "test" {
+  name     = "%[1]s"
+  location = "WestEurope"
+}
+resource "azurerm_virtual_network" "test" {
+  name                = "aztfexport-test-%[2]s"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+`, d.RandomRgName(), d.RandomStringOfLength(8))
+}
+
+func (CaseVnet) Total() int {
+	return 3
+}
+
+func (CaseVnet) ResourceMapping(d test.Data) (resmap.ResourceMapping, error) {
+	return test.ResourceMapping(fmt.Sprintf(`{
+{{ "/subscriptions/%[1]s/resourcegroups/%[2]s" | Quote }}: {
+  "resource_type": "azurerm_resource_group",
+  "resource_name": "test",
+  "resource_id": "/subscriptions/%[1]s/resourceGroups/%[2]s"
+},
+
+{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.network/virtualnetworks/aztfexport-test-%[3]s" | Quote }}: {
+  "resource_type": "azurerm_virtual_network",
+  "resource_name": "test",
+  "resource_id": "/subscriptions/%[1]s/resourceGroups/%[2]s/providers/Microsoft.Network/virtualNetworks/aztfexport-test-%[3]s"
+},
+
+{{ "/subscriptions/%[1]s/resourcegroups/%[2]s/providers/microsoft.network/virtualnetworks/aztfexport-test-%[3]s/subnets/internal" | Quote }}: {
+  "resource_type": "azurerm_subnet",
+  "resource_name": "test",
+  "resource_id": "/subscriptions/%[1]s/resourceGroups/%[2]s/providers/Microsoft.Network/virtualNetworks/aztfexport-test-%[3]s/subnets/internal"
+}
+
+}
+`, d.SubscriptionId, d.RandomRgName(), d.RandomStringOfLength(8)))
+}
+
+func (CaseVnet) SingleResourceContext(d test.Data) ([]SingleResourceContext, error) {
+	return []SingleResourceContext{
+		{
+			AzureId:             fmt.Sprintf("/subscriptions/%[1]s/resourceGroups/%[2]s", d.SubscriptionId, d.RandomRgName()),
+			ExpectResourceCount: 1,
+		},
+		{
+			AzureId:             fmt.Sprintf("/subscriptions/%[1]s/resourceGroups/%[2]s/providers/Microsoft.Network/virtualNetworks/aztfexport-test-%[3]s", d.SubscriptionId, d.RandomRgName(), d.RandomStringOfLength(8)),
+			ExpectResourceCount: 1,
+		},
+		{
+			AzureId:             fmt.Sprintf("/subscriptions/%[1]s/resourceGroups/%[2]s/providers/Microsoft.Network/virtualNetworks/aztfexport-test-%[3]s/subnets/internal", d.SubscriptionId, d.RandomRgName(), d.RandomStringOfLength(8)),
+			ExpectResourceCount: 1,
+		},
+	}, nil
+}

--- a/internal/test/resmap/e2e_cases_test.go
+++ b/internal/test/resmap/e2e_cases_test.go
@@ -96,6 +96,13 @@ func runCase(t *testing.T, d test.Data, c cases.Case) {
 	test.Verify(t, ctx, aztfexportDir, tfexecPath, len(resMapping))
 }
 
+func TestVnet(t *testing.T) {
+	t.Parallel()
+	test.Precheck(t)
+	c, d := cases.CaseVnet{}, test.NewData()
+	runCase(t, d, c)
+}
+
 func TestComputeVMDisk(t *testing.T) {
 	t.Parallel()
 	test.Precheck(t)

--- a/internal/test/resourcegroup/e2e_cases_test.go
+++ b/internal/test/resourcegroup/e2e_cases_test.go
@@ -87,6 +87,13 @@ func runCase(t *testing.T, d test.Data, c cases.Case) {
 	test.Verify(t, ctx, aztfexportDir, tfexecPath, c.Total())
 }
 
+func TestVnet(t *testing.T) {
+	t.Parallel()
+	test.Precheck(t)
+	c, d := cases.CaseVnet{}, test.NewData()
+	runCase(t, d, c)
+}
+
 func TestComputeVMDisk(t *testing.T) {
 	t.Parallel()
 	test.Precheck(t)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -103,8 +103,8 @@ type Config struct {
 
 	// Exactly one of below is specified
 
-	// ResourceId specifies the Azure resource id, this indicates the resource mode.
-	ResourceId string
+	// ResourceIds specifies the list of Azure resource ids, this indicates the resource mode.
+	ResourceIds []string
 	// ResourceGroupName specifies the name of the resource group, this indicates the resource group mode.
 	ResourceGroupName string
 	// ARGPredicate specifies the ARG where predicate, this indicates the query mode.
@@ -112,7 +112,7 @@ type Config struct {
 	// MappingFile specifies the path of mapping file, this indicates the map file mode.
 	MappingFile string
 
-	// ResourceNamePattern specifies the resource name pattern, this only applies to resource group mode and query mode.
+	// ResourceNamePattern specifies the resource name pattern, this only applies to resource group mode, query mode and multi-resource mode.
 	ResourceNamePattern string
 
 	// RecursiveQuery specifies whether to recursively list the child/proxy resources of the ARG resulted resource list, this only applies to query mode.

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -27,7 +27,7 @@ func NewMeta(cfg config.Config) (Meta, error) {
 		return meta.NewMetaQuery(cfg)
 	case cfg.MappingFile != "":
 		return meta.NewMetaMap(cfg)
-	case cfg.ResourceId != "":
+	case len(cfg.ResourceIds) != 0:
 		return meta.NewMetaResource(cfg)
 	default:
 		return nil, fmt.Errorf("invalid group config")


### PR DESCRIPTION
This PR extends the `aztfexport resource` subcommand, to allow multiple resource ids. The argument can be a list of mixtures of azure resource id, or a file path prefixed by `@`, which contains azure resource ids line by line.

Fix #550
Fix #545