### PR TITLE
Return error for non-existent resources when using terraformless export

### DIFF
--- a/internal/meta/base_meta.go
+++ b/internal/meta/base_meta.go
@@ -924,7 +924,6 @@ func (meta *baseMeta) importItem_notf(ctx context.Context, item *ImportItem, imp
 		return
 	}
 	res := importResp.ImportedResources[0]
-
 	readResp, diags := meta.tfclient.ReadResource(ctx, typ.ReadResourceRequest{
 		TypeName:   res.TypeName,
 		PriorState: res.State,


### PR DESCRIPTION
Previously, when using terraformless export (i.e. `-tfclient-plugin-path`), if the resource/resource group to be exported doesn't exit, an empty HCL block will still be generated.

This PR adds additional check after the ReadResource RPC call, to raise error if the state read is nil. This logic exists in `terraform` (@internal/terraform/node_resource_import.go), that's why terraform export will correctly raise the error for non-existent resources.