### PR TITLE
Using `resource_provider_registrations` to skip registration of RP

### DIFF
--- a/internal/meta/base_meta.go
+++ b/internal/meta/base_meta.go
@@ -268,7 +268,7 @@ func NewBaseMeta(cfg config.CommonConfig) (*baseMeta, error) {
 	setIfNoExist("use_oidc", cty.BoolVal(cfg.AuthConfig.UseOIDC))
 
 	// Update provider config for provider registration
-	setIfNoExist("skip_provider_registration", cty.BoolVal(true))
+	setIfNoExist("resource_provider_registrations", cty.StringVal("none"))
 
 	meta := &baseMeta{
 		logger:             cfg.Logger,


### PR DESCRIPTION
This is due to the original way of disabling RP registration is now deprecated in the latest v4 azurerm provider.