### PR TITLE
Query mode: Supports `--arg-table` and `--arg-authorization-scope-filter`

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@v2.21.1
+        uses: securego/gosec@v2.21.4
         with:
           args: './...'
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@v2.21.4
+        uses: securego/gosec@v2.21.1
         with:
           args: './...'
 

--- a/command_before_func.go
+++ b/command_before_func.go
@@ -3,9 +3,11 @@ package main
 import (
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/Azure/aztfexport/internal/utils"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph"
 	"github.com/hashicorp/terraform-config-inspect/tfconfig"
 	"github.com/urfave/cli/v2"
 )
@@ -111,6 +113,12 @@ func commandBeforeFunc(fset *FlagSet, mode Mode) func(ctx *cli.Context) error {
 				}
 				if fset.flagResName != "" {
 					return fmt.Errorf("`--name` can't be specified for multi-resource mode")
+				}
+			}
+		case ModeQuery:
+			if fset.flagARGAuthorizationScopeFilter != "" {
+				if !slices.Contains(armresourcegraph.PossibleAuthorizationScopeFilterValues(), armresourcegraph.AuthorizationScopeFilter(fset.flagARGAuthorizationScopeFilter)) {
+					return fmt.Errorf("invalid value of `--arg-authorization-scope-filter`")
 				}
 			}
 		}

--- a/flag.go
+++ b/flag.go
@@ -87,12 +87,16 @@ type FlagSet struct {
 	// flagRecursive
 	// flagIncludeRoleAssignment
 	// flagIncludeResourceGroup
-	flagPattern               string
-	flagRecursive             bool
-	flagResName               string
-	flagResType               string
-	flagIncludeRoleAssignment bool
-	flagIncludeResourceGroup  bool
+	// flagARGTable
+	// flagARGAuthorizationScopeFilter
+	flagPattern                     string
+	flagRecursive                   bool
+	flagResName                     string
+	flagResType                     string
+	flagIncludeRoleAssignment       bool
+	flagIncludeResourceGroup        bool
+	flagARGTable                    string
+	flagARGAuthorizationScopeFilter string
 }
 
 type Mode string
@@ -250,6 +254,12 @@ func (flag FlagSet) DescribeCLI(mode Mode) string {
 		}
 		if flag.flagIncludeResourceGroup {
 			args = append(args, "--include-resource-group=true")
+		}
+		if flag.flagARGTable != "" {
+			args = append(args, "--arg-table="+flag.flagARGTable)
+		}
+		if flag.flagARGAuthorizationScopeFilter != "" {
+			args = append(args, "--arg-authorization-scope-filter="+flag.flagARGAuthorizationScopeFilter)
 		}
 	}
 	return "aztfexport " + strings.Join(args, " ")

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.9.2
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.5.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault v1.0.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.6.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1
 	github.com/charmbracelet/bubbles v0.14.0
 	github.com/charmbracelet/bubbletea v0.22.1
@@ -78,7 +79,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/paloaltonetworksngfw/armpanngfw v1.0.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservicesbackup v1.0.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/recoveryservices/armrecoveryservicessiterecovery v1.1.0 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.6.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeploymentscripts v1.0.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/securityinsights/armsecurityinsights/v2 v2.0.0-beta.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/hashicorp/terraform-json v0.22.1
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/magodo/armid v0.0.0-20240524082432-7ce06ae46c33
-	github.com/magodo/azlist v0.0.0-20240903084323-b329fe33ce23
+	github.com/magodo/azlist v0.0.0-20240926110356-8798310310af
 	github.com/magodo/aztft v0.3.1-0.20240823092950-b8a7f3cdf3ae
 	github.com/magodo/slog2hclog v0.0.0-20240614031327-090ebd72a033
 	github.com/magodo/spinner v0.0.0-20240524082745-3a2305db1bdc

--- a/go.sum
+++ b/go.sum
@@ -233,6 +233,8 @@ github.com/magodo/armid v0.0.0-20240524082432-7ce06ae46c33 h1:KmQ16pNsI7DaELU+Cb
 github.com/magodo/armid v0.0.0-20240524082432-7ce06ae46c33/go.mod h1:rR8E7zfGMbmfnSQvrkFiWYdhrfTqsVSltelnZB09BwA=
 github.com/magodo/azlist v0.0.0-20240903084323-b329fe33ce23 h1:99U0TtE+gi7EjXi3Lo6sKFReU2ID2f2wK2gCJSz8/Ow=
 github.com/magodo/azlist v0.0.0-20240903084323-b329fe33ce23/go.mod h1:xefFDOxzRssOEjGoxvrO8jeTWlzHXbY6sCJYOt+Jh5k=
+github.com/magodo/azlist v0.0.0-20240926110356-8798310310af h1:r55nPAyFztYNdXNVmZgNtDU6AbKbfdy/Cbg6xnOnidM=
+github.com/magodo/azlist v0.0.0-20240926110356-8798310310af/go.mod h1:xefFDOxzRssOEjGoxvrO8jeTWlzHXbY6sCJYOt+Jh5k=
 github.com/magodo/aztft v0.3.1-0.20240823092950-b8a7f3cdf3ae h1:+2PWj5sHws1EsOmStkdiMA5vjgchGGyasSfcNZ6Cbj4=
 github.com/magodo/aztft v0.3.1-0.20240823092950-b8a7f3cdf3ae/go.mod h1:swhCPmbwehJXrVgu8SCr/XFb2e9tkgEp+Wnnv3K0ZsQ=
 github.com/magodo/slog2hclog v0.0.0-20240614031327-090ebd72a033 h1:K2seYsMAzoICCLdDe7uU2WyaACLW+tvdTWG3QB+pyec=

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,6 @@ github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/magodo/armid v0.0.0-20240524082432-7ce06ae46c33 h1:KmQ16pNsI7DaELU+CbqZKXVdvkE/YXqMH6LLkp6rw/Y=
 github.com/magodo/armid v0.0.0-20240524082432-7ce06ae46c33/go.mod h1:rR8E7zfGMbmfnSQvrkFiWYdhrfTqsVSltelnZB09BwA=
-github.com/magodo/azlist v0.0.0-20240903084323-b329fe33ce23 h1:99U0TtE+gi7EjXi3Lo6sKFReU2ID2f2wK2gCJSz8/Ow=
-github.com/magodo/azlist v0.0.0-20240903084323-b329fe33ce23/go.mod h1:xefFDOxzRssOEjGoxvrO8jeTWlzHXbY6sCJYOt+Jh5k=
 github.com/magodo/azlist v0.0.0-20240926110356-8798310310af h1:r55nPAyFztYNdXNVmZgNtDU6AbKbfdy/Cbg6xnOnidM=
 github.com/magodo/azlist v0.0.0-20240926110356-8798310310af/go.mod h1:xefFDOxzRssOEjGoxvrO8jeTWlzHXbY6sCJYOt+Jh5k=
 github.com/magodo/aztft v0.3.1-0.20240823092950-b8a7f3cdf3ae h1:+2PWj5sHws1EsOmStkdiMA5vjgchGGyasSfcNZ6Cbj4=

--- a/main.go
+++ b/main.go
@@ -421,6 +421,18 @@ func main() {
 			Usage:       "Include the resource groups that the exported resources belong to",
 			Destination: &flagset.flagIncludeResourceGroup,
 		},
+		&cli.StringFlag{
+			Name:        "arg-table",
+			EnvVars:     []string{"AZTFEXPORT_ARG_TABLE"},
+			Usage:       `The Azure Resource Graph table name. Defaults to "Resources".`,
+			Destination: &flagset.flagARGTable,
+		},
+		&cli.StringFlag{
+			Name:        "arg-authorization-scope-filter",
+			EnvVars:     []string{"AZTFEXPORT_ARG_AUTHORIZATION_SCOPE_FILTER"},
+			Usage:       `The Azure Resource Graph Authorization Scope Filter parameter. Possible values are: "AtScopeAndBelow", "AtScopeAndAbove", "AtScopeAboveAndBelow" and "AtScopeExact"`,
+			Destination: &flagset.flagARGAuthorizationScopeFilter,
+		},
 	}, resourceGroupFlags...)
 
 	mappingFileFlags := append([]cli.Flag{}, commonFlags...)
@@ -608,12 +620,14 @@ func main() {
 
 					// Initialize the config
 					cfg := config.Config{
-						CommonConfig:          commonConfig,
-						ARGPredicate:          predicate,
-						ResourceNamePattern:   flagset.flagPattern,
-						RecursiveQuery:        flagset.flagRecursive,
-						IncludeRoleAssignment: flagset.flagIncludeRoleAssignment,
-						IncludeResourceGroup:  flagset.flagIncludeResourceGroup,
+						CommonConfig:                commonConfig,
+						ARGPredicate:                predicate,
+						ResourceNamePattern:         flagset.flagPattern,
+						RecursiveQuery:              flagset.flagRecursive,
+						IncludeRoleAssignment:       flagset.flagIncludeRoleAssignment,
+						IncludeResourceGroup:        flagset.flagIncludeResourceGroup,
+						ARGTable:                    flagset.flagARGTable,
+						ARGAuthorizationScopeFilter: flagset.flagARGAuthorizationScopeFilter,
 					}
 
 					return realMain(c.Context, cfg, flagset.flagNonInteractive, flagset.hflagMockClient, flagset.flagPlainUI, flagset.flagGenerateMappingFile, flagset.hflagProfile, flagset.DescribeCLI(ModeQuery), flagset.hflagTFClientPluginPath)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -112,20 +112,35 @@ type Config struct {
 	// MappingFile specifies the path of mapping file, this indicates the map file mode.
 	MappingFile string
 
-	// ResourceNamePattern specifies the resource name pattern, this only applies to resource group mode, query mode and multi-resource mode.
+	/////////////////////////
+	// Scope: rg, res (multi), query
+
+	// ResourceNamePattern specifies the resource name pattern
 	ResourceNamePattern string
 
-	// RecursiveQuery specifies whether to recursively list the child/proxy resources of the ARG resulted resource list, this only applies to query mode.
-	RecursiveQuery bool
+	/////////////////////////
+	// Scope: rg, query
 
-	// TFResourceName specifies the TF resource name, this only applies to resource mode.
-	TFResourceName string
-	// TFResourceName specifies the TF resource type (if empty, will try to deduce the type), this only applies to resource mode.
-	TFResourceType string
-
-	// IncludeRoleAssignment specifies whether to include the role assginments assigned to the exported resources, this only applies to rg and query mode
+	// IncludeRoleAssignment specifies whether to include the role assginments assigned to the exported resources
 	IncludeRoleAssignment bool
 
-	// IncludeResourceGroup specifies whether to include the resource groups that the exported resources belong to, this only applies to query mode
+	/////////////////////////
+	// Scope: res (single)
+
+	// TFResourceName specifies the TF resource name
+	TFResourceName string
+	// TFResourceName specifies the TF resource type (if empty, will try to deduce the type)
+	TFResourceType string
+
+	/////////////////////////
+	// Scope: query
+
+	// RecursiveQuery specifies whether to recursively list the child/proxy resources of the ARG resulted resource list
+	RecursiveQuery bool
+	// IncludeResourceGroup specifies whether to include the resource groups that the exported resources belong to
 	IncludeResourceGroup bool
+	// ARGTable specifies the ARG table name, which defaults to the "Resources" table
+	ARGTable string
+	//  ARGAuthorizationScopeFilter specifies the AuthorizationScopeFilter parameter. Possible values are: "AtScopeAndBelow", "AtScopeAndAbove", "AtScopeAboveAndBelow" and "AtScopeExact"
+	ARGAuthorizationScopeFilter string
 }


### PR DESCRIPTION
This PR adds support for `--arg-table` and `--arg-authorization-scope-filter` in query mode.

- `--arg-table`: This allows users to specify ARG table name other than the "Resources" (default) table. See https://learn.microsoft.com/en-us/azure/governance/resource-graph/concepts/query-language#resource-graph-tables for the complete list
- `--arg-authorization-scope-filter`: This allows users to modify the authZ scope filter parameter in the ARG query. Detailed information can be found at: https://learn.microsoft.com/en-us/azure/governance/resource-graph/concepts/query-language#query-scope

Fix https://github.com/Azure/aztfexport/issues/550