### PR TITLE
tfinstall: Remove version check

### DIFF
--- a/internal/meta/tfinstall_find.go
+++ b/internal/meta/tfinstall_find.go
@@ -3,7 +3,6 @@ package meta
 import (
 	"context"
 
-	"github.com/hashicorp/go-version"
 	install "github.com/hashicorp/hc-install"
 	"github.com/hashicorp/hc-install/fs"
 	"github.com/hashicorp/hc-install/product"
@@ -14,9 +13,8 @@ import (
 func FindTerraform(ctx context.Context) (string, error) {
 	i := install.NewInstaller()
 	return i.Ensure(ctx, []src.Source{
-		&fs.Version{
-			Product:     product.Terraform,
-			Constraints: version.MustConstraints(version.NewConstraint(">=0.12")),
+		&fs.AnyVersion{
+			Product: &product.Terraform,
 		},
 	})
 }


### PR DESCRIPTION
Removing the version check as most users are now at version later than 0.12.0. Also, the version check will not accept dev version, which is an unnecessary restrict.

Relating to: https://github.com/Azure/aztfexport/issues/582