### PR TITLE
`pkg/meta`: New function `NewDummyMeta` to export the DummyMeta implementation

### DIFF
--- a/internal/meta/meta_dummy.go
+++ b/internal/meta/meta_dummy.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Azure/aztfexport/pkg/config"
+	"github.com/magodo/armid"
 )
 
 type MetaGroupDummy struct {
@@ -46,23 +47,22 @@ func (m MetaGroupDummy) Workspace() string {
 
 func (m MetaGroupDummy) ListResource(_ context.Context) (ImportList, error) {
 	time.Sleep(500 * time.Millisecond)
-	return ImportList{
-		ImportItem{
-			TFResourceId: "/subscriptions/0000000-0000-0000-0000-00000000000/resourceGroups/example-rg/providers/Microsoft.Network/virtualNetworks/example-network",
-		},
-		ImportItem{
-			TFResourceId: "/subscriptions/0000000-0000-0000-0000-00000000000/resourceGroups/example-rg/providers/Microsoft.Compute/virtualMachines/example-machine",
-		},
-		ImportItem{
-			TFResourceId: "/subscriptions/0000000-0000-0000-0000-00000000000/resourceGroups/example-rg/providers/Microsoft.Network/networkInterfaces/example-nic",
-		},
-		ImportItem{
-			TFResourceId: "/subscriptions/0000000-0000-0000-0000-00000000000/resourceGroups/example-rg/providers/Microsoft.Network/virtualNetworks/example-network/subnets/internal",
-		},
-		ImportItem{
-			TFResourceId: "/subscriptions/0000000-0000-0000-0000-00000000000/resourceGroups/example-rg",
-		},
-	}, nil
+	importList := make(ImportList, 0)
+	ids := []string{
+		"/subscriptions/0000000-0000-0000-0000-00000000000/resourceGroups/example-rg/providers/Microsoft.Network/virtualNetworks/example-network",
+		"/subscriptions/0000000-0000-0000-0000-00000000000/resourceGroups/example-rg/providers/Microsoft.Compute/virtualMachines/example-machine",
+		"/subscriptions/0000000-0000-0000-0000-00000000000/resourceGroups/example-rg/providers/Microsoft.Network/networkInterfaces/example-nic",
+		"/subscriptions/0000000-0000-0000-0000-00000000000/resourceGroups/example-rg/providers/Microsoft.Network/virtualNetworks/example-network/subnets/internal",
+		"/subscriptions/0000000-0000-0000-0000-00000000000/resourceGroups/example-rg",
+	}
+	for _, id := range ids {
+		azureResourceID, _ := armid.ParseResourceId(id)
+		importList = append(importList, ImportItem{
+			TFResourceId:    id,
+			AzureResourceID: azureResourceID,
+		})
+	}
+	return importList, nil
 }
 
 func (m MetaGroupDummy) CleanTFState(_ context.Context, _ string) {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -33,3 +33,7 @@ func NewMeta(cfg config.Config) (Meta, error) {
 		return nil, fmt.Errorf("invalid group config")
 	}
 }
+
+func NewDummyMeta(cfg config.Config) (Meta, error) {
+	return meta.NewGroupMetaDummy(cfg.ResourceGroupName, cfg.ProviderName), nil
+}

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -1,0 +1,33 @@
+package meta_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/aztfexport/pkg/config"
+	"github.com/Azure/aztfexport/pkg/meta"
+)
+
+func TestNewDummyMeta(t *testing.T) {
+	cfg := config.Config{
+		CommonConfig: config.CommonConfig{
+			ProviderName: "test-provider",
+		},
+		ResourceGroupName: "test-rg",
+	}
+
+	meta, err := meta.NewDummyMeta(cfg)
+	if err != nil {
+		t.Fatalf("NewDummyMeta: expected no error, got %v", err)
+	}
+
+	resources, err := meta.ListResource(context.Background())
+	if err != nil {
+		t.Fatalf("ListResource: expected no error, got %v", err)
+	}
+
+	expectedNumResources := 5
+	if len(resources) != expectedNumResources {
+		t.Fatalf("ListResource: expected %d resources, got %d", expectedNumResources, len(resources))
+	}
+}


### PR DESCRIPTION
Adds new function `NewDummyMeta` that does not call any external API on import. This is useful for integration testing use case.