### PR TITLE
Use implicit dependency instead of depends_on

### DIFF
--- a/internal/meta/base_meta.go
+++ b/internal/meta/base_meta.go
@@ -1149,7 +1149,7 @@ func (meta baseMeta) addDependency(configs ConfigInfos) (ConfigInfos, error) {
 
 	for _, cfg := range configs {
 		if len(cfg.DependsOn) != 0 {
-			if err := hclBlockAppendDependency(cfg.hcl.Body().Blocks()[0].Body(), cfg.DependsOn, configSet); err != nil {
+			if err := hclBlockUpdateDependency(cfg.hcl.Body().Blocks()[0].Body(), cfg.DependsOn, configSet); err != nil {
 				return nil, err
 			}
 		}

--- a/internal/meta/config_info.go
+++ b/internal/meta/config_info.go
@@ -36,13 +36,13 @@ func (cfgs ConfigInfos) AddDependency() error {
 		return err
 	}
 
-	// Disduplicate then sort the dependencies
+	// Deduplicate then sort the dependencies
 	for i, cfg := range cfgs {
 		if len(cfg.DependsOn) == 0 {
 			continue
 		}
 
-		// Disduplicate same resource ids that has exact one candidate
+		// Deduplicate same resource ids that has exact one candidate
 		set := map[string]bool{}
 		duplicates := []Dependency{}
 		for _, dep := range cfg.DependsOn {
@@ -53,7 +53,7 @@ func (cfgs ConfigInfos) AddDependency() error {
 			}
 		}
 
-		// Disduplicate dependency that is parent of another dependency
+		// Deduplicate dependency that is parent of another dependency
 		var covlist []string
 		for dep := range set {
 			for odep := range set {

--- a/internal/meta/hcl_edit.go
+++ b/internal/meta/hcl_edit.go
@@ -42,10 +42,8 @@ func hclBlockUpdateDependency(body *hclwrite.Body, deps []Dependency, cfgset map
 	return nil
 }
 
-// Traverse the attribute tokens and replace all TFResourceId-valued tokens
-// surrounded with quotes with TFAddr.
-// This function recurse through nested blocks.
-// Returns true if any replacement was made
+// Traverse the attribute tokens and replace all TFResourceId-valued token surrounded with quotes with TFAddr.
+// This function recurse through nested blocks. Returns true if any replacement was made
 func replaceIdValuedTokensWithTFAddr(body *hclwrite.Body, cfg ConfigInfo) bool {
 	resourceId := cfg.TFResourceId
 	ret := false

--- a/internal/meta/hcl_edit_test.go
+++ b/internal/meta/hcl_edit_test.go
@@ -3,7 +3,10 @@ package meta
 import (
 	"testing"
 
+	"github.com/Azure/aztfexport/internal/tfaddr"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/magodo/armid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,4 +39,134 @@ func TestHclBlockAppendLifecycle(t *testing.T) {
 		require.NoError(t, hclBlockAppendLifecycle(b, c.ignoreChanges), c.name)
 		require.Equal(t, string(hclwrite.Format(b.BuildTokens(nil).Bytes())), c.expect, c.name)
 	}
+}
+
+func TestReplaceIdAttrValuesWithTFAddr(t *testing.T) {
+	cases := []struct {
+		caseNo          int
+		depResourceId   string
+		depTfAddr       string
+		inputHclBody    string
+		expectedHclBody string
+		expectedRetVal  bool
+	}{
+		{
+			caseNo:        1,
+			depResourceId: "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123",
+			depTfAddr:     "azurerm_foo_resource.example",
+			inputHclBody: `
+  name   = "test"
+  foo_id = "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123"
+`,
+			expectedHclBody: `
+  name   = "test"
+  foo_id = azurerm_foo_resource.example.id
+`,
+			expectedRetVal: true,
+		},
+		{
+			caseNo:        2,
+			depResourceId: "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123",
+			depTfAddr:     "azurerm_foo_resource.example",
+			inputHclBody: `
+  name   = "test"
+  foo_x_id = "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123"
+  foo_y_id = "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123"
+`,
+			expectedHclBody: `
+  name   = "test"
+  foo_x_id = azurerm_foo_resource.example.id
+  foo_y_id = azurerm_foo_resource.example.id
+`,
+			expectedRetVal: true,
+		},
+		{
+			caseNo:        3,
+			depResourceId: "/subscriptions/123/resourceGroups/123/providers/Microsoft.Bar/bar/123",
+			depTfAddr:     "azurerm_bar_resource.example",
+			inputHclBody: `
+  name   = "test"
+  foo_id = "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123"
+`,
+			expectedHclBody: `
+  name   = "test"
+  foo_id = "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123"
+`,
+			expectedRetVal: false,
+		},
+		{
+			caseNo:        4,
+			depResourceId: "/subscriptions/123/resourceGroups/123/providers/Microsoft.Bar/bar/123",
+			depTfAddr:     "azurerm_bar_resource.example",
+			inputHclBody: `
+  name   = "test"
+  foo_id = "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123"
+`,
+			expectedHclBody: `
+  name   = "test"
+  foo_id = "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123"
+`,
+			expectedRetVal: false,
+		},
+		{
+			caseNo:          5,
+			depResourceId:   "/subscriptions/123/resourceGroups/123/providers/Microsoft.Bar/bar/123",
+			depTfAddr:       "azurerm_bar_resource.example",
+			inputHclBody:    ``,
+			expectedHclBody: ``,
+			expectedRetVal:  false,
+		},
+		{
+			caseNo:        6,
+			depResourceId: "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123",
+			depTfAddr:     "azurerm_foo_resource.example",
+			inputHclBody: `
+  name    = "test"
+  foo_ids = [ "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123" ]
+`,
+			expectedHclBody: `
+  name   = "test"
+  foo_id = [ azurerm_foo_resource.example.id ]
+`,
+			expectedRetVal: false,
+		},
+	}
+
+	for _, c := range cases {
+		cfg := configInfo(t, c.depResourceId, c.depTfAddr)
+		body := hclwriteBody(t, c.inputHclBody)
+
+		actualRetVal := replaceIdAttrValuesWithTFAddr(body, cfg)
+
+		require.Equal(t, c.expectedRetVal, actualRetVal, "case %d: expectedRetVal should match actual", c.caseNo)
+		require.Equal(t, c.expectedHclBody, string(body.BuildTokens(nil).Bytes()), "case %d: expectedHclBody should match actual", c.caseNo)
+	}
+
+}
+
+func configInfo(t *testing.T, resourceId string, tfAddr string) ConfigInfo {
+	azureResourceId, err := armid.ParseResourceId(resourceId)
+	if err != nil {
+		t.Fatalf("failed to parse azure resource id: %v", err)
+	}
+
+	tfResourceAddr, err := tfaddr.ParseTFResourceAddr(tfAddr)
+	if err != nil {
+		t.Fatalf("failed to parse tf resource addr: %v", err)
+	}
+
+	return ConfigInfo{
+		ImportItem: ImportItem{
+			TFAddr:          *tfResourceAddr,
+			AzureResourceID: azureResourceId,
+		},
+	}
+}
+
+func hclwriteBody(t *testing.T, input string) *hclwrite.Body {
+	file, diag := hclwrite.ParseConfig([]byte(input), "input.hcl", hcl.InitialPos)
+	if diag.HasErrors() {
+		t.Fatalf("failed to parse HCL: %v", diag)
+	}
+	return file.Body()
 }

--- a/internal/meta/hcl_edit_test.go
+++ b/internal/meta/hcl_edit_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/Azure/aztfexport/internal/tfaddr"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclwrite"
-	"github.com/magodo/armid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -41,19 +40,19 @@ func TestHclBlockAppendLifecycle(t *testing.T) {
 	}
 }
 
-func TestReplaceIdAttrValuesWithTFAddr(t *testing.T) {
+func TestReplaceIdValuedTokensWithTFAddr(t *testing.T) {
 	cases := []struct {
 		description     string
-		depResourceId   string
+		depTfResourceId string
 		depTfAddr       string
 		inputHclBody    string
 		expectedHclBody string
 		expectedRetVal  bool
 	}{
 		{
-			description:   "single id value should be replaced with tf addr",
-			depResourceId: "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123",
-			depTfAddr:     "azurerm_foo_resource.example",
+			description:     "single id value should be replaced with tf addr",
+			depTfResourceId: "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123",
+			depTfAddr:       "azurerm_foo_resource.example",
 			inputHclBody: `
   name   = "test"
   foo_id = "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123"
@@ -65,25 +64,25 @@ func TestReplaceIdAttrValuesWithTFAddr(t *testing.T) {
 			expectedRetVal: true,
 		},
 		{
-			description:   "multiple id values should be replaced with tf addr",
-			depResourceId: "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123",
-			depTfAddr:     "azurerm_foo_resource.example",
+			description:     "multiple id values should be replaced with tf addr",
+			depTfResourceId: "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123",
+			depTfAddr:       "azurerm_foo_resource.example",
 			inputHclBody: `
-  name   = "test"
+  name     = "test"
   foo_x_id = "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123"
   foo_y_id = "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123"
 `,
 			expectedHclBody: `
-  name   = "test"
+  name     = "test"
   foo_x_id = azurerm_foo_resource.example.id
   foo_y_id = azurerm_foo_resource.example.id
 `,
 			expectedRetVal: true,
 		},
 		{
-			description:   "no replacement if no id value matches",
-			depResourceId: "/subscriptions/123/resourceGroups/123/providers/Microsoft.Bar/bar/123",
-			depTfAddr:     "azurerm_bar_resource.example",
+			description:     "no replacement if no id value matches",
+			depTfResourceId: "/subscriptions/123/resourceGroups/123/providers/Microsoft.Bar/bar/123",
+			depTfAddr:       "azurerm_bar_resource.example",
 			inputHclBody: `
   name   = "test"
   foo_id = "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123"
@@ -95,34 +94,82 @@ func TestReplaceIdAttrValuesWithTFAddr(t *testing.T) {
 			expectedRetVal: false,
 		},
 		{
-			description:     "empty hcl body",
-			depResourceId:   "/subscriptions/123/resourceGroups/123/providers/Microsoft.Bar/bar/123",
+			description:     "empty block",
+			depTfResourceId: "/subscriptions/123/resourceGroups/123/providers/Microsoft.Bar/bar/123",
 			depTfAddr:       "azurerm_bar_resource.example",
 			inputHclBody:    ``,
 			expectedHclBody: ``,
 			expectedRetVal:  false,
 		},
 		{
-			description:   "id value in a list",
-			depResourceId: "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123",
-			depTfAddr:     "azurerm_foo_resource.example",
+			description:     "id value in a list",
+			depTfResourceId: "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123",
+			depTfAddr:       "azurerm_foo_resource.example",
 			inputHclBody: `
   name    = "test"
-  foo_ids = [ "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123" ]
+  foo_ids = [ 
+    "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123",
+    "/this/should/not/be/changed",
+  ]
 `,
 			expectedHclBody: `
-  name   = "test"
-  foo_id = [ azurerm_foo_resource.example.id ]
+  name    = "test"
+  foo_ids = [ 
+    azurerm_foo_resource.example.id,
+    "/this/should/not/be/changed",
+  ]
 `,
-			expectedRetVal: false,
+			expectedRetVal: true,
+		},
+		{
+			description:     "id value in a map",
+			depTfResourceId: "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123",
+			depTfAddr:       "azurerm_foo_resource.example",
+			inputHclBody: `
+  name    = "test"
+  foo_ids_map = {
+    fst = "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123",
+    snd = "/this/should/not/be/changed",
+  }
+`,
+			expectedHclBody: `
+  name    = "test"
+  foo_ids_map = {
+    fst = azurerm_foo_resource.example.id,
+    snd = "/this/should/not/be/changed",
+  }
+`,
+			expectedRetVal: true,
+		},
+		{
+			description:     "id value in a nested block",
+			depTfResourceId: "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123",
+			depTfAddr:       "azurerm_foo_resource.example",
+			inputHclBody: `
+  name    = "test"
+  some_block {
+    foo_ids = [
+      "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123"
+    ]
+  }
+`,
+			expectedHclBody: `
+  name    = "test"
+  some_block {
+    foo_ids = [
+      azurerm_foo_resource.example.id
+    ]
+  }
+`,
+			expectedRetVal: true,
 		},
 	}
 
 	for _, c := range cases {
-		cfg := configInfo(t, c.depResourceId, c.depTfAddr)
+		cfg := configInfo(t, c.depTfResourceId, c.depTfAddr)
 		body := hclwriteBody(t, c.inputHclBody)
 
-		actualRetVal := replaceIdAttrValuesWithTFAddr(body, cfg)
+		actualRetVal := replaceIdValuedTokensWithTFAddr(body, cfg)
 
 		require.Equal(t, c.expectedRetVal, actualRetVal, "'%s': expectedRetVal should match actual", c.description)
 		require.Equal(t, c.expectedHclBody, string(body.BuildTokens(nil).Bytes()), "'%s': expectedHclBody should match actual", c.description)
@@ -130,21 +177,16 @@ func TestReplaceIdAttrValuesWithTFAddr(t *testing.T) {
 
 }
 
-func configInfo(t *testing.T, resourceId string, tfAddr string) ConfigInfo {
-	azureResourceId, err := armid.ParseResourceId(resourceId)
-	if err != nil {
-		t.Fatalf("failed to parse azure resource id: %v", err)
-	}
-
+func configInfo(t *testing.T, tfResourceId string, tfAddr string) ConfigInfo {
 	tfResourceAddr, err := tfaddr.ParseTFResourceAddr(tfAddr)
 	if err != nil {
-		t.Fatalf("failed to parse tf resource addr: %v", err)
+		t.Fatalf("failed to parse tfAddr: %v", err)
 	}
 
 	return ConfigInfo{
 		ImportItem: ImportItem{
-			TFAddr:          *tfResourceAddr,
-			AzureResourceID: azureResourceId,
+			TFAddr:       *tfResourceAddr,
+			TFResourceId: tfResourceId,
 		},
 	}
 }

--- a/internal/meta/hcl_edit_test.go
+++ b/internal/meta/hcl_edit_test.go
@@ -43,7 +43,7 @@ func TestHclBlockAppendLifecycle(t *testing.T) {
 
 func TestReplaceIdAttrValuesWithTFAddr(t *testing.T) {
 	cases := []struct {
-		caseNo          int
+		description     string
 		depResourceId   string
 		depTfAddr       string
 		inputHclBody    string
@@ -51,7 +51,7 @@ func TestReplaceIdAttrValuesWithTFAddr(t *testing.T) {
 		expectedRetVal  bool
 	}{
 		{
-			caseNo:        1,
+			description:   "single id value should be replaced with tf addr",
 			depResourceId: "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123",
 			depTfAddr:     "azurerm_foo_resource.example",
 			inputHclBody: `
@@ -65,7 +65,7 @@ func TestReplaceIdAttrValuesWithTFAddr(t *testing.T) {
 			expectedRetVal: true,
 		},
 		{
-			caseNo:        2,
+			description:   "multiple id values should be replaced with tf addr",
 			depResourceId: "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123",
 			depTfAddr:     "azurerm_foo_resource.example",
 			inputHclBody: `
@@ -81,7 +81,7 @@ func TestReplaceIdAttrValuesWithTFAddr(t *testing.T) {
 			expectedRetVal: true,
 		},
 		{
-			caseNo:        3,
+			description:   "no replacement if no id value matches",
 			depResourceId: "/subscriptions/123/resourceGroups/123/providers/Microsoft.Bar/bar/123",
 			depTfAddr:     "azurerm_bar_resource.example",
 			inputHclBody: `
@@ -95,21 +95,7 @@ func TestReplaceIdAttrValuesWithTFAddr(t *testing.T) {
 			expectedRetVal: false,
 		},
 		{
-			caseNo:        4,
-			depResourceId: "/subscriptions/123/resourceGroups/123/providers/Microsoft.Bar/bar/123",
-			depTfAddr:     "azurerm_bar_resource.example",
-			inputHclBody: `
-  name   = "test"
-  foo_id = "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123"
-`,
-			expectedHclBody: `
-  name   = "test"
-  foo_id = "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123"
-`,
-			expectedRetVal: false,
-		},
-		{
-			caseNo:          5,
+			description:     "empty hcl body",
 			depResourceId:   "/subscriptions/123/resourceGroups/123/providers/Microsoft.Bar/bar/123",
 			depTfAddr:       "azurerm_bar_resource.example",
 			inputHclBody:    ``,
@@ -117,7 +103,7 @@ func TestReplaceIdAttrValuesWithTFAddr(t *testing.T) {
 			expectedRetVal:  false,
 		},
 		{
-			caseNo:        6,
+			description:   "id value in a list",
 			depResourceId: "/subscriptions/123/resourceGroups/123/providers/Microsoft.Foo/foo/123",
 			depTfAddr:     "azurerm_foo_resource.example",
 			inputHclBody: `
@@ -138,8 +124,8 @@ func TestReplaceIdAttrValuesWithTFAddr(t *testing.T) {
 
 		actualRetVal := replaceIdAttrValuesWithTFAddr(body, cfg)
 
-		require.Equal(t, c.expectedRetVal, actualRetVal, "case %d: expectedRetVal should match actual", c.caseNo)
-		require.Equal(t, c.expectedHclBody, string(body.BuildTokens(nil).Bytes()), "case %d: expectedHclBody should match actual", c.caseNo)
+		require.Equal(t, c.expectedRetVal, actualRetVal, "'%s': expectedRetVal should match actual", c.description)
+		require.Equal(t, c.expectedHclBody, string(body.BuildTokens(nil).Bytes()), "'%s': expectedHclBody should match actual", c.description)
 	}
 
 }


### PR DESCRIPTION
Improved export logic such that when resourceId-valued attribute is matched against a dependency resource, use implicit TF address instead of depends_on syntax.

Config exported in previous behaviour:

```
// The id of this resource is "/subscription/123/resourceGroup/123/providers/Foo/foo/foo1"
resource "azurerm_foo_resource" "example" {
  name = "foo1"
}

resource "azurerm_bar_resource" "example" {
  name = "bar1"
  foo_id = "/subscription/123/resourceGroup/123/providers/Foo/foo/foo1"
  depends_on = [
    azurerm_foo_resource.example
  ]
}
```

Config exported in the new behaviour:

```
resource "azurerm_foo_resource" "example" {
  name = "foo1"
}

resource "azurerm_bar_resource" "example" {
  name = "bar1"
  foo_id = azurerm_foo_resource.example.id
}
```

If no such value is found, it will still fall-back to depends_on.
The replacement is done in recursive manner. Values nested in children blocks will also be replaced.