### PR TITLE
Resource mode: Avoid the API calls (and any potential error) if only exporting for the specified resources

### DIFF
--- a/internal/meta/meta_query.go
+++ b/internal/meta/meta_query.go
@@ -65,10 +65,6 @@ func (meta *MetaQuery) ListResource(ctx context.Context) (ImportList, error) {
 		meta.Logger().Debug("Azure Resource set map to TF resource set")
 		rl = rset.ToTFAzAPIResources()
 	} else {
-		meta.Logger().Debug("Populate resource set")
-		if err := rset.PopulateResource(); err != nil {
-			return nil, fmt.Errorf("tweaking single resources in the azure resource set: %v", err)
-		}
 		meta.Logger().Debug("Reduce resource set")
 		if err := rset.ReduceResource(); err != nil {
 			return nil, fmt.Errorf("tweaking across resources in the azure resource set: %v", err)
@@ -133,8 +129,7 @@ func (meta MetaQuery) queryResourceSet(ctx context.Context, predicate string, re
 	var rl []resourceset.AzureResource
 	for _, res := range result.Resources {
 		res := resourceset.AzureResource{
-			Id:         res.Id,
-			Properties: res.Properties,
+			Id: res.Id,
 		}
 		rl = append(rl, res)
 	}

--- a/internal/meta/meta_rg.go
+++ b/internal/meta/meta_rg.go
@@ -52,10 +52,6 @@ func (meta *MetaResourceGroup) ListResource(ctx context.Context) (ImportList, er
 	if meta.useAzAPI() {
 		rl = rset.ToTFAzAPIResources()
 	} else {
-		meta.Logger().Debug("Populate resource set")
-		if err := rset.PopulateResource(); err != nil {
-			return nil, fmt.Errorf("tweaking single resources in the azure resource set: %v", err)
-		}
 		meta.Logger().Debug("Reduce resource set")
 		if err := rset.ReduceResource(); err != nil {
 			return nil, fmt.Errorf("tweaking across resources in the azure resource set: %v", err)
@@ -116,8 +112,7 @@ func (meta MetaResourceGroup) queryResourceSet(ctx context.Context, rg string) (
 	}
 	for _, res := range result.Resources {
 		res := resourceset.AzureResource{
-			Id:         res.Id,
-			Properties: res.Properties,
+			Id: res.Id,
 		}
 		rl = append(rl, res)
 	}
@@ -148,8 +143,7 @@ func (meta MetaResourceGroup) queryResourceSet(ctx context.Context, rg string) (
 	}
 	for _, res := range result.Resources {
 		res := resourceset.AzureResource{
-			Id:         res.Id,
-			Properties: res.Properties,
+			Id: res.Id,
 		}
 		rl = append(rl, res)
 	}

--- a/internal/resourceset/azure_resource_set.go
+++ b/internal/resourceset/azure_resource_set.go
@@ -17,8 +17,7 @@ type AzureResourceSet struct {
 }
 
 type AzureResource struct {
-	Id         armid.ResourceId
-	Properties map[string]interface{}
+	Id armid.ResourceId
 }
 
 type PesudoResourceInfo struct {

--- a/internal/resourceset/azure_resource_set_hack.go
+++ b/internal/resourceset/azure_resource_set_hack.go
@@ -1,30 +1,10 @@
 package resourceset
 
 import (
-	"encoding/json"
-	"fmt"
 	"strings"
 
 	"github.com/magodo/armid"
-
-	"github.com/tidwall/gjson"
 )
-
-// PopulateResourceTypes is a map to record resources that might to be populate other resources.
-// This is used in single resource mode to decide whether to call API to get its body.
-var PopulateResourceTypes = map[string]bool{
-	"MICROSOFT.COMPUTE/VIRTUALMACHINES": true,
-}
-
-// PopulateResource populate single resource for certain Azure resouce type that is known might maps to more than one TF resources, which are missing from azlist.
-// In most cases, this step is used to populate the Azure managed resource.
-func (rset *AzureResourceSet) PopulateResource() error {
-	// Populate managed data disk (and the association) for VMs that are missing from Azure exported resource set.
-	if err := rset.populateForVirtualMachine(); err != nil {
-		return err
-	}
-	return nil
-}
 
 // ReduceResource reduce the resource set for certain multiple Azure resources that are known to be mapped to only one TF resource.
 func (rset *AzureResourceSet) ReduceResource() error {
@@ -62,45 +42,4 @@ func (rset *AzureResourceSet) reduceForKeyVaultCertificate() error {
 	}
 	rset.Resources = newResoruces
 	return nil
-}
-
-func (rset *AzureResourceSet) populateForVirtualMachine() error {
-	for _, res := range rset.Resources[:] {
-		if strings.ToUpper(res.Id.RouteScopeString()) != "/MICROSOFT.COMPUTE/VIRTUALMACHINES" {
-			continue
-		}
-		disks, err := populateManagedResourcesByPath(res, "properties.storageProfile.dataDisks.#.managedDisk.id")
-		if err != nil {
-			return fmt.Errorf(`populating managed disks for %q: %v`, res.Id, err)
-		}
-		rset.Resources = append(rset.Resources, disks...)
-	}
-	return nil
-}
-
-// populateManagedResourcesByPath populate the managed resources in the specified paths.
-func populateManagedResourcesByPath(res AzureResource, paths ...string) ([]AzureResource, error) {
-	b, err := json.Marshal(res.Properties)
-	if err != nil {
-		return nil, fmt.Errorf("marshaling %v: %v", res.Properties, err)
-	}
-	var resources []AzureResource
-	for _, path := range paths {
-		result := gjson.GetBytes(b, path)
-		if !result.Exists() {
-			continue
-		}
-
-		for _, exprResult := range result.Array() {
-			mid := exprResult.String()
-			id, err := armid.ParseResourceId(mid)
-			if err != nil {
-				return nil, fmt.Errorf("parsing managed resource id %s: %v", mid, err)
-			}
-			resources = append(resources, AzureResource{
-				Id: id,
-			})
-		}
-	}
-	return resources, nil
 }


### PR DESCRIPTION
With #643, the resource mode will always need to use `azlist` to do a GET for each resource, no matter if it is necessary or not. Due to the design of `azlist`, it internally uses a resource type file to lookup the correct API versions to use for each resource type. This might cause issues if the resource type is a relatively new one, which is not available in the (outdated) resource type file (see: #648).

Instead, if the user doesn't need to query more resources than what are specified (e.g. child resource, extension resource, etc.), there is no need to call into `azlist`. In this case, we can simply return the resource set as is specified.

Additionally, this PR removes the `Properties` from type `resourceset.AzureResource`. The `Properties` are meant to be returned from `azlist`, and is used only for one specific case of populating managed disks for VM. This is not needed any more, which was introduced before `aztft` exits, and was leveraging the ARM template. See: https://github.com/Azure/aztfexport/issues/34.