### PR TITLE
Update `tfadd` for a fix on default value check for dynamic types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/magodo/spinner v0.0.0-20240524082745-3a2305db1bdc
 	github.com/magodo/terraform-client-go v0.0.0-20240804032252-6d93a97fabb2
 	github.com/magodo/textinput v0.0.0-20210913072708-7d24f2b4b0c0
-	github.com/magodo/tfadd v0.10.1-0.20260706234035-0f34bf6309b2
+	github.com/magodo/tfadd v0.10.1-0.20260819041323-ec85c46cd91e
 	github.com/magodo/tfmerge v0.0.0-20221214062955-f52e46d03402
 	github.com/magodo/tfstate v0.0.0-20241016043929-2c95177bf0e6
 	github.com/magodo/workerpool v0.0.0-20240524082508-11838001bc35

--- a/go.sum
+++ b/go.sum
@@ -270,8 +270,8 @@ github.com/magodo/terraform-client-go v0.0.0-20240804032252-6d93a97fabb2 h1:X2ph
 github.com/magodo/terraform-client-go v0.0.0-20240804032252-6d93a97fabb2/go.mod h1:dzTs6Qwy8/VUWYMQ+Vo9gMXe5uOVbfCw/1ovE3g5q1E=
 github.com/magodo/textinput v0.0.0-20210913072708-7d24f2b4b0c0 h1:aNtr4iNv/tex2t8W1u3scAoNHEnFlTKhNNHOpYStqbs=
 github.com/magodo/textinput v0.0.0-20210913072708-7d24f2b4b0c0/go.mod h1:MqYhNP+PC386Bjsx5piZe7T4vDm5QIPv8b1RU0prVnU=
-github.com/magodo/tfadd v0.10.1-0.20260706234035-0f34bf6309b2 h1:fRsFgLDtrOKodz/ZMO8d4ur0STru6Bgw9ZB+QR7Pf/s=
-github.com/magodo/tfadd v0.10.1-0.20260706234035-0f34bf6309b2/go.mod h1:Ul9tfUbNokUeWnT/xzwvqxxma7mJRMG5pUjz2H/cY1w=
+github.com/magodo/tfadd v0.10.1-0.20260819041323-ec85c46cd91e h1:Qu2kkQexG897mJJ7yVKZgU7XVIokNTn5BfSObfvap0I=
+github.com/magodo/tfadd v0.10.1-0.20260819041323-ec85c46cd91e/go.mod h1:Ul9tfUbNokUeWnT/xzwvqxxma7mJRMG5pUjz2H/cY1w=
 github.com/magodo/tfmerge v0.0.0-20221214062955-f52e46d03402 h1:RyaR4VE7hoR9AyoVH414cpM8V63H4rLe2aZyKdoDV1w=
 github.com/magodo/tfmerge v0.0.0-20221214062955-f52e46d03402/go.mod h1:ssV++b4DH33rsD592bvpS4Peng3ZfdGNZbFgCDkCfj8=
 github.com/magodo/tfpluginschema v0.0.0-20240902090353-0525d7d8c1c2 h1:Unxx8WLxzSxINnq7hItp4cXD7drihgfPltTd91efoBo=


### PR DESCRIPTION
When setting `--config-mode` to a value other than `full`, the new equality check logic of `tfadd` might cause an error when comparing default values on a dynamic attribute. E.g.:

> converting default value map[]: can't convert Go map dynamically; only cty.Value allowed

I've made a [fix](ec85c46cd91e59fe968772fc71cc3ebb7088144c) in the `tfadd`. This PR just updates `tfadd` to bring the fix in.