### PR TITLE
NamePattern: Change the default suffix from `*` to `+` (which is the original `*`)

### DIFF
--- a/internal/meta/name_pattern.go
+++ b/internal/meta/name_pattern.go
@@ -49,9 +49,9 @@ type nameExpander struct {
 }
 
 func newNameExpander(pattern string) *nameExpander {
-	// An `*` is implicitly appended at the end when no index character is specified.
+	// An `+` is implicitly appended at the end when no index character is specified.
 	if !strings.ContainsAny(pattern, idxChars) {
-		pattern += string(idxOptional)
+		pattern += string(idxAlways)
 	}
 
 	pos := strings.IndexAny(pattern, idxChars)

--- a/internal/meta/name_pattern_test.go
+++ b/internal/meta/name_pattern_test.go
@@ -71,7 +71,7 @@ func TestNameExpander(t *testing.T) {
 		// The `*` is implicitly appended.
 		e := newNameExpander("res")
 		got := []string{e.Expand(vm1), e.Expand(vm2), e.Expand(vnet)}
-		want := []string{"res", "res2", "res"}
+		want := []string{"res1", "res2", "res1"}
 		for i := range got {
 			if got[i] != want[i] {
 				t.Errorf("[%d] = %q, want %q", i, got[i], want[i])
@@ -125,7 +125,7 @@ func TestNameExpander(t *testing.T) {
 		e := newNameExpander("{type}")
 		got := []string{e.Expand(vm1), e.Expand(vm2), e.Expand(vnet)}
 		// Per-prefix counter restarts per distinct expanded prefix.
-		want := []string{"virtual_machines", "virtual_machines2", "virtual_networks"}
+		want := []string{"virtual_machines1", "virtual_machines2", "virtual_networks1"}
 		for i := range got {
 			if got[i] != want[i] {
 				t.Errorf("[%d] = %q, want %q", i, got[i], want[i])
@@ -136,7 +136,7 @@ func TestNameExpander(t *testing.T) {
 	t.Run("name-and-root_scope-placeholders", func(t *testing.T) {
 		e := newNameExpander("{root_scope}_{name}")
 		got := e.Expand(vm1)
-		want := "my_rg_vmone"
+		want := "my_rg_vmone1"
 		if got != want {
 			t.Errorf("= %q, want %q", got, want)
 		}
@@ -145,7 +145,7 @@ func TestNameExpander(t *testing.T) {
 	t.Run("rp-placeholder", func(t *testing.T) {
 		e := newNameExpander("{rp}_{type}")
 		got := e.Expand(vm1)
-		want := "microsoft_compute_virtual_machines"
+		want := "microsoft_compute_virtual_machines1"
 		if got != want {
 			t.Errorf("= %q, want %q", got, want)
 		}

--- a/main.go
+++ b/main.go
@@ -92,7 +92,7 @@ func prepareConfigFile(ctx *cli.Context) error {
 	return nil
 }
 
-const namePatternUsage = `The pattern of the resource name. The pattern supports at most one index character, either '*' or '+' (exclusively): both expands to an incremental type-scoped index, '*' outputs no suffix for the first element, then 2, 3 and so on, where '+' output 1, 2, and so on. If none is specified, a '*' is implicitly appended at the end of the pattern. The pattern also supports a set of placeholders that are expanded per resource: {type} (the last Azure resource type segment, snake_cased, e.g. 'virtual_machines'), {rp} (the Azure resource provider namespace, snake_cased, e.g. 'microsoft_compute'), {name} (the last name segment of the Azure resource id, snake_cased), {root_scope} (the root scope of the resource, snake_cased, e.g. the resource group name). E.g. '{type}' may expand to 'virtual_machines', 'virtual_machines2', ...`
+const namePatternUsage = `The pattern of the resource name. The pattern supports at most one index character, either '*' or '+' (exclusively): both expands to an incremental type-scoped index, '*' outputs no suffix for the first element, then 2, 3 and so on, where '+' output 1, 2, and so on. If none is specified, a '+' is implicitly appended at the end of the pattern. The pattern also supports a set of placeholders that are expanded per resource: {type} (the last Azure resource type segment, snake_cased, e.g. 'virtual_machines'), {rp} (the Azure resource provider namespace, snake_cased, e.g. 'microsoft_compute'), {name} (the last name segment of the Azure resource id, snake_cased), {root_scope} (the root scope of the resource, snake_cased, e.g. the resource group name). E.g. '{type}*' may expand to 'virtual_machines', 'virtual_machines2', ...`
 
 func main() {
 	commonFlags := []cli.Flag{
@@ -424,7 +424,7 @@ func main() {
 			EnvVars:     []string{"AZTFEXPORT_NAME_PATTERN"},
 			Aliases:     []string{"p"},
 			Usage:       namePatternUsage + " (only works for multi-resource mode).",
-			Value:       "res-+",
+			Value:       "res-",
 			Destination: &flagset.flagPattern,
 		},
 		&cli.BoolFlag{
@@ -448,7 +448,7 @@ func main() {
 			EnvVars:     []string{"AZTFEXPORT_NAME_PATTERN"},
 			Aliases:     []string{"p"},
 			Usage:       namePatternUsage,
-			Value:       "res",
+			Value:       "res-",
 			Destination: &flagset.flagPattern,
 		},
 	}, commonFlags...)
@@ -459,7 +459,7 @@ func main() {
 			EnvVars:     []string{"AZTFEXPORT_NAME_PATTERN"},
 			Aliases:     []string{"p"},
 			Usage:       namePatternUsage,
-			Value:       "res-+",
+			Value:       "res-",
 			Destination: &flagset.flagPattern,
 		},
 		&cli.BoolFlag{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -148,7 +148,7 @@ type Config struct {
 	//                    same name is shared by more than one resource. Otherwise, it
 	//                    expands to an empty string
 	//   '+'            - always expands to an incremental index, starting from 1
-	// If none is specified, a '*' is implicitly appended at the end of the pattern.
+	// If none is specified, a '+' is implicitly appended at the end of the pattern.
 	//
 	// The pattern also supports the following per-resource placeholders, expanded
 	// based on the parsed Azure resource id and the recommended TF resource type:
@@ -161,7 +161,7 @@ type Config struct {
 	ResourceNamePattern string
 
 	// IncludeExtensions specifies the set of extension resource types to include for the exported resources.
-	// Supported values are defined in the meta package (e.g. "role-assignment").
+	// Supported values are defined in the meta package (e.g. "role-assignments").
 	IncludeExtensions []string
 
 	// IncludeManagedResource specifies whether to allow service team/3rd party managed resources to be exported


### PR DESCRIPTION
This is to keep the default behavior without the need to change the default value.